### PR TITLE
fix: desativa CI quebrado (ingestão CVM 401 + limite de cron do Worker)

### DIFF
--- a/.github/workflows/ingest-cvm.yml
+++ b/.github/workflows/ingest-cvm.yml
@@ -16,9 +16,10 @@ name: Ingestão CVM (diária)
 # Base URL padrão: EI_API_URL secret (se ausente, usa o default do script).
 
 on:
-  schedule:
-    # Todo dia às 02:00 BRT (UTC-3) = 05:00 UTC.
-    - cron: "0 5 * * *"
+  # Schedule desativado em 2026-07-23: EI_ADMIN_TOKEN expirado, falhando
+  # com 401 (nao_autenticado) todo dia. Reativar após renovar o secret.
+  # schedule:
+  #   - cron: "0 5 * * *"
   workflow_dispatch:
     inputs:
       mes:

--- a/servidores/porta-entrada/wrangler.toml
+++ b/servidores/porta-entrada/wrangler.toml
@@ -9,12 +9,15 @@ database_id = "e2a0b0a8-484d-4507-b21c-facf090481dd"
 preview_database_id = "e2a0b0a8-484d-4507-b21c-facf090481dd"
 migrations_dir = "../../infra/banco/migrations"
 
-[triggers]
-crons = [
-  "*/5 * * * *",
-  "0 3 * * *",
-  "*/30 * * * *",
-]
+# Crons removidos em 2026-07-23: deploy do Worker falhava com "exceeded the
+# limit of 5 cron triggers" (limite é por conta Cloudflare, não por Worker).
+# Reativar quando houver espaço de cron liberado na conta.
+# [triggers]
+# crons = [
+#   "*/5 * * * *",
+#   "0 3 * * *",
+#   "*/30 * * * *",
+# ]
 
 [vars]
 GOOGLE_APPS_SCRIPT_WEBHOOK_URL = "https://script.google.com/macros/s/AKfycbzwrYNylQiyaWuC8gXsUDAYOC1QROvfWQ9DCiZ32GfNba9Zsxnj4_tUmREmXtS2Xt75/exec"


### PR DESCRIPTION
## Contexto
Duas falhas recorrentes no Actions:
- `Ingestão CVM (diária)` falhando todo dia com `401 nao_autenticado` — `EI_ADMIN_TOKEN` expirado.
- `Deploy to Cloudflare` falhando ao registrar cron triggers do Worker — limite de 5 crons por conta Cloudflare excedido (não é por Worker).

## Mudanças
- Schedule da ingestão CVM comentado; `workflow_dispatch` continua disponível pra rodar manual.
- 3 crons removidos do `wrangler.toml` do `ei-api-gateway` (cotações 5min, histórico mensal 3h, fila de reconstrução 30min) — deploy volta a ficar verde, mas os jobs cron ficam pausados até liberar espaço de cron na conta.

## Pendências (fora de escopo deste PR)
- Renovar `EI_ADMIN_TOKEN` e reativar o schedule da ingestão CVM.
- Decidir onde liberar espaço de cron na conta Cloudflare e reativar os 3 triggers do Worker.

## Test plan
- [ ] CI (typecheck + deploy) passa verde neste PR