### PR TITLE
fix: aceita patrimônio CVM negativo

### DIFF
--- a/servidores/porta-entrada/src/dominios/admin/admin.rotas.ts
+++ b/servidores/porta-entrada/src/dominios/admin/admin.rotas.ts
@@ -17,7 +17,7 @@ const cotasSchema = z.object({
     cnpj: z.string().min(1),
     data: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
     valorCota: z.number().positive(),
-    patrimonioLiquidoBrl: z.number().nonnegative().optional(),
+    patrimonioLiquidoBrl: z.number().finite().optional(),
   })).min(1).max(5000),
 });
 

--- a/servidores/porta-entrada/testes/cvm-ingestao.servico.test.ts
+++ b/servidores/porta-entrada/testes/cvm-ingestao.servico.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { normalizarCnpjCvm, normalizarDataCvm } from '../src/dominios/admin/cvm-ingestao.servico';
+import { normalizarCnpjCvm, normalizarDataCvm, servicoCvmIngestao } from '../src/dominios/admin/cvm-ingestao.servico';
 
 test('normaliza CNPJ CVM com ou sem pontuação', () => {
   assert.equal(normalizarCnpjCvm('12.345.678/0001-90'), '12345678000190');
@@ -10,4 +10,19 @@ test('normaliza CNPJ CVM com ou sem pontuação', () => {
 test('aceita somente data CVM no formato canônico', () => {
   assert.equal(normalizarDataCvm('2026-07-25'), '2026-07-25');
   assert.equal(normalizarDataCvm('25/07/2026'), null);
+});
+
+test('aceita cota CVM com patrimônio líquido negativo', async () => {
+  const lotes: { sql: string; valores: unknown[] }[][] = [];
+  const bd = {
+    consultar: async () => [],
+    primeiro: async () => ({ id: 'execucao-1' }),
+    executar: async () => ({ sucesso: true, linhasAfetadas: 1 }),
+    emLote: async (operacoes: { sql: string; valores: unknown[] }[]) => { lotes.push(operacoes); },
+  };
+  const resultado = await servicoCvmIngestao(bd).ingerirCotas('execucao-1', [{
+    cnpj: '12.345.678/0001-90', data: '2026-07-25', valorCota: 1.23, patrimonioLiquidoBrl: -10,
+  }]);
+  assert.equal(resultado.ok, true);
+  assert.equal(lotes[0][1].valores[3], -10);
 });


### PR DESCRIPTION
Corrige a validação da ingestão CVM para aceitar patrimônio líquido negativo, valor permitido pelos dados da fonte. Validado com typecheck e testes de API.