### PR TITLE
Filtra ingestao CVM pelo patrimonio ativo

### DIFF
--- a/servidores/porta-entrada/src/dominios/admin/admin.rotas.ts
+++ b/servidores/porta-entrada/src/dominios/admin/admin.rotas.ts
@@ -51,6 +51,9 @@ export async function rotearAdmin(
   if (tokenServicoCvm && caminho === '/api/admin/cvm/execucoes' && metodo === 'POST') {
     return cvm.abrirExecucao(execucaoSchema.parse(await lerJson(request)));
   }
+  if (tokenServicoCvm && caminho === '/api/admin/cvm/cnpjs-alvo' && metodo === 'GET') {
+    return cvm.listarCnpjsAlvo();
+  }
   if (tokenServicoCvm && caminho === '/api/admin/cvm/cotas' && metodo === 'POST') {
     const entrada = cotasSchema.parse(await lerJson(request));
     return cvm.ingerirCotas(entrada.execucaoId, entrada.itens);

--- a/servidores/porta-entrada/src/dominios/admin/cvm-ingestao.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/admin/cvm-ingestao.repositorio.ts
@@ -8,6 +8,19 @@ export interface CotaCvmPersistida {
 }
 
 export const repositorioCvmIngestao = (bd: Bd) => ({
+  async listarCnpjsAlvo(): Promise<string[]> {
+    const linhas = await bd.consultar<{ cnpj: string }>(
+      `SELECT DISTINCT a.cnpj
+         FROM ativos a
+         INNER JOIN patrimonio_itens p ON p.ativo_id = a.id
+        WHERE p.esta_ativo = 1
+          AND a.tipo IN ('fundo', 'previdencia')
+          AND a.cnpj IS NOT NULL
+          AND length(trim(a.cnpj)) > 0`,
+    );
+    return linhas.map((linha) => linha.cnpj.replace(/\D/g, '')).filter((cnpj) => cnpj.length === 14);
+  },
+
   async criarExecucao(id: string, parametrosJson: string): Promise<void> {
     await bd.executar(
       `INSERT INTO cvm_execucoes (id, modo, status, parametros_json)

--- a/servidores/porta-entrada/src/dominios/admin/cvm-ingestao.servico.ts
+++ b/servidores/porta-entrada/src/dominios/admin/cvm-ingestao.servico.ts
@@ -35,6 +35,10 @@ export function normalizarDataCvm(valor: string): string | null {
 }
 
 export const servicoCvmIngestao = (bd: Bd) => ({
+  async listarCnpjsAlvo(): Promise<ServiceResponse<{ cnpjs: string[] }>> {
+    return sucesso({ cnpjs: await repositorioCvmIngestao(bd).listarCnpjsAlvo() });
+  },
+
   async abrirExecucao(entrada: ExecucaoCvmEntrada): Promise<ServiceResponse<{ id: string }>> {
     const id = gerarId();
     await repositorioCvmIngestao(bd).criarExecucao(id, JSON.stringify(entrada));

--- a/servidores/porta-entrada/testes/cvm-ingestao.servico.test.ts
+++ b/servidores/porta-entrada/testes/cvm-ingestao.servico.test.ts
@@ -26,3 +26,14 @@ test('aceita cota CVM com patrimônio líquido negativo', async () => {
   assert.equal(resultado.ok, true);
   assert.equal(lotes[0][1].valores[3], -10);
 });
+
+test('retorna somente CNPJs válidos usados pelo patrimônio', async () => {
+  const bd = {
+    consultar: async () => [{ cnpj: '12.345.678/0001-90' }, { cnpj: 'invalido' }],
+    primeiro: async () => null,
+    executar: async () => ({ sucesso: true, linhasAfetadas: 0 }),
+    emLote: async () => {},
+  };
+  const resultado = await servicoCvmIngestao(bd).listarCnpjsAlvo();
+  assert.deepEqual(resultado, { ok: true, dados: { cnpjs: ['12345678000190'] } });
+});

--- a/utilitarios/scripts/ingest-cvm-funds.mjs
+++ b/utilitarios/scripts/ingest-cvm-funds.mjs
@@ -45,7 +45,7 @@ import { dirname } from "node:path";
 
 const API_BASE_URL = (process.env.EI_API_URL || "https://ei-api-gateway.giammattey-luiz.workers.dev").replace(/\/$/, "");
 const ADMIN_TOKEN = process.env.EI_ADMIN_TOKEN;
-const TAMANHO_LOTE = 4000; // endpoint aceita até 5000, deixa margem
+const TAMANHO_LOTE = 500;
 const TMP_DIR = ".tmp-cvm";
 
 const args = new Map();
@@ -135,20 +135,31 @@ async function fetchComRetry(url, opts = {}, tentativas = 3) {
 }
 
 async function apiJson(path, opts = {}) {
-  const res = await fetchComRetry(`${API_BASE_URL}${path}`, {
-    ...opts,
-    headers: {
-      ...(opts.headers ?? {}),
-      "content-type": "application/json",
-      authorization: `Bearer ${ADMIN_TOKEN}`,
-      "x-admin-token": ADMIN_TOKEN,
-    },
-  });
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok || !body?.ok) {
-    throw new Error(`${opts.method || "GET"} ${path} falhou (${res.status}): ${JSON.stringify(body).slice(0, 300)}`);
+  for (let tentativa = 0; tentativa < 4; tentativa += 1) {
+    const res = await fetchComRetry(`${API_BASE_URL}${path}`, {
+      ...opts,
+      headers: {
+        ...(opts.headers ?? {}),
+        "content-type": "application/json",
+        authorization: `Bearer ${ADMIN_TOKEN}`,
+        "x-admin-token": ADMIN_TOKEN,
+      },
+    });
+    const body = await res.json().catch(() => ({}));
+    if (res.ok && body?.ok) return body.dados;
+    if (![429, 503, 504].includes(res.status) || tentativa === 3) {
+      throw new Error(`${opts.method || "GET"} ${path} falhou (${res.status}): ${JSON.stringify(body).slice(0, 300)}`);
+    }
+    const esperaMs = 1_000 * 2 ** tentativa;
+    console.warn(`  ${path} respondeu ${res.status}; nova tentativa em ${esperaMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, esperaMs));
   }
-  return body.dados;
+  throw new Error(`${opts.method || "GET"} ${path} excedeu tentativas`);
+}
+
+async function listarCnpjsAlvo() {
+  const dados = await apiJson('/api/admin/cvm/cnpjs-alvo');
+  return new Set((dados.cnpjs ?? []).map(normalizarCnpj).filter(Boolean));
 }
 
 async function abrirRun(referenciaAnoMes) {
@@ -261,8 +272,14 @@ async function ingerirMes(anoMes) {
 
   console.log(`\n▶ Ingestão CVM ${anoMes} (origem=${origemExecucao})`);
 
+  const cnpjsAlvo = await listarCnpjsAlvo();
   const runId = await abrirRun(anoMes);
   console.log(`  runId=${runId}`);
+  if (cnpjsAlvo.size === 0) {
+    await atualizarRun(runId, { status: 'concluido', arquivosProcessados: 0, registrosLidos: 0, registrosValidos: 0, registrosInvalidos: 0 });
+    console.log('  Nenhum fundo ativo com CNPJ; ingestão não necessária.');
+    return { ok: true, runId, totalLidos: 0, totalValidos: 0, totalInvalidos: 0 };
+  }
 
   let caminhoLocal;
   try {
@@ -287,6 +304,7 @@ async function ingerirMes(anoMes) {
       totalLidos += 1;
       const parsed = parseLinhaCvm(row);
       if (!parsed.ok) { totalInvalidos += 1; continue; }
+      if (!cnpjsAlvo.has(parsed.item.cnpj)) continue;
       lote.push(parsed.item);
       if (lote.length >= TAMANHO_LOTE) {
         const r = await postarLoteCotas(runId, lote);


### PR DESCRIPTION
## O que mudou
- consulta os CNPJs de fundos e previdencia realmente ativos no patrimonio antes da ingestao
- encerra sem download quando nao ha CNPJ alvo
- reduz lotes para 500 cotas e repete somente falhas transitorias

## Por que
A tentativa anterior processou a base inteira da CVM e gerou carga excessiva no Worker/D1. A aplicacao deve ingerir somente ativos que a carteira usa.

## Validacao
- npm.cmd run typecheck
- npm.cmd run test:api
- npm.cmd run build