### PR TITLE
Atualiza Actions para Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ingest-cvm.yml
+++ b/.github/workflows/ingest-cvm.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Executar ingestão CVM
         env:


### PR DESCRIPTION
## O que mudou
- atualiza as Actions de deploy e ingestao CVM de Node 20 para Node 24

## Por que
Os runners do GitHub ja avisavam que Node 20 esta depreciado.

## Validacao
- Node v24.16.0
- npm.cmd run typecheck
- npm.cmd run test:api