### PR TITLE
Atualiza runtime interno das Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/ingest-cvm.yml
+++ b/.github/workflows/ingest-cvm.yml
@@ -39,10 +39,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 


### PR DESCRIPTION
## O que mudou
- atualiza checkout e setup-node para v5, que executam no runtime Node 24

## Por que
Mesmo com o projeto em Node 24, o aviso vinha das actions v4 que usavam Node 20 internamente.

## Validacao
- Node v24.16.0
- npm.cmd run typecheck
- npm.cmd run test:api