### PR TITLE
Vincula CNPJ de fundos ao patrimônio canônico

### DIFF
--- a/bibliotecas/contratos/patrimonio.ts
+++ b/bibliotecas/contratos/patrimonio.ts
@@ -32,6 +32,7 @@ export interface ItemPatrimonioSaida {
 
 export interface ItemPatrimonioCriarEntrada {
   ativoId?: string | null;
+  cnpj?: string | null;
   tipo: TipoItemPatrimonio;
   nome: string;
   quantidade?: number | null;
@@ -42,6 +43,7 @@ export interface ItemPatrimonioCriarEntrada {
 }
 
 export interface ItemPatrimonioAtualizarEntrada {
+  cnpj?: string | null;
   tipo?: TipoItemPatrimonio;
   nome?: string;
   quantidade?: number | null;

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -116,6 +116,19 @@ export interface LinhaImportacao {
 }
 
 export const repositorioPatrimonio = (bd: Bd) => ({
+  async buscarAtivoPorCnpj(cnpj: string) {
+    return bd.primeiro<{ id: string }>(`SELECT id FROM ativos WHERE cnpj = ? LIMIT 1`, cnpj);
+  },
+
+  async inserirAtivoComCnpj(id: string, cnpj: string, tipo: string, nome: string): Promise<void> {
+    await bd.executar(
+      `INSERT INTO ativos (id, cnpj, nome, tipo)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(cnpj) DO NOTHING`,
+      id, cnpj, nome, tipo,
+    );
+  },
+
   async resumo(usuarioId: string) {
     return bd.primeiro<LinhaResumo>(
       `SELECT * FROM vw_patrimonio_resumo WHERE usuario_id = ? LIMIT 1`,
@@ -179,6 +192,7 @@ export const repositorioPatrimonio = (bd: Bd) => ({
   async atualizarItem(
     id: string, usuarioId: string,
     campos: {
+      ativoId?: string | null;
       tipo?: string; nome?: string; quantidade?: number | null;
       precoMedioBrl?: number | null; valorAtualBrl?: number | null;
       moeda?: string; estaAtivo?: boolean; dadosJson?: string;
@@ -187,6 +201,7 @@ export const repositorioPatrimonio = (bd: Bd) => ({
     const partes: string[] = [];
     const vals: unknown[] = [];
     const set = (col: string, v: unknown) => { partes.push(`${col} = ?`); vals.push(v); };
+    if (campos.ativoId !== undefined) set('ativo_id', campos.ativoId);
     if (campos.tipo !== undefined) set('tipo', campos.tipo);
     if (campos.nome !== undefined) set('nome', campos.nome);
     if (campos.quantidade !== undefined) set('quantidade', campos.quantidade);

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -76,6 +76,13 @@ const paraAlocacaoSaida = (linhas: LinhaAlocacao[]): AlocacaoClasse[] => {
   return base.map((b, i) => ({ ...b, pesoPct: calculado[i].pesoPct }));
 };
 
+const normalizarCnpjPatrimonial = (valor: string): string | null => {
+  const cnpj = valor.replace(/\D/g, '');
+  return cnpj.length === 14 ? cnpj : null;
+};
+
+const aceitaCnpj = (tipo: TipoItemPatrimonio): boolean => tipo === 'fundo' || tipo === 'previdencia';
+
 export const servicoPatrimonio = (bd: Bd) => {
   const repo = repositorioPatrimonio(bd);
 
@@ -140,9 +147,23 @@ export const servicoPatrimonio = (bd: Bd) => {
 
     async criarItem(usuarioId: string, e: ItemPatrimonioCriarEntrada): Promise<ServiceResponse<ItemPatrimonioSaida>> {
       if (!e.tipo || !e.nome) return erro('dados_incompletos', 'Tipo e nome são obrigatórios', 400);
+      let ativoId = e.ativoId ?? null;
+      if (e.cnpj !== undefined && e.cnpj !== null) {
+        if (!aceitaCnpj(e.tipo)) return erro('cnpj_tipo_invalido', 'CNPJ só pode ser usado em fundos ou previdência', 400);
+        const cnpj = normalizarCnpjPatrimonial(e.cnpj);
+        if (!cnpj) return erro('cnpj_invalido', 'Informe um CNPJ com 14 dígitos', 400);
+        const existente = await repo.buscarAtivoPorCnpj(cnpj);
+        if (existente) ativoId = existente.id;
+        else {
+          await repo.inserirAtivoComCnpj(gerarId(), cnpj, e.tipo, e.nome);
+          const criado = await repo.buscarAtivoPorCnpj(cnpj);
+          if (!criado) return erro('ativo_nao_encontrado', 'Não foi possível vincular o CNPJ ao ativo', 500);
+          ativoId = criado.id;
+        }
+      }
       const id = gerarId();
       await repo.inserirItem(
-        id, usuarioId, e.ativoId ?? null, e.tipo, 'manual', e.nome,
+        id, usuarioId, ativoId, e.tipo, 'manual', e.nome,
         e.quantidade ?? null, e.precoMedioBrl ?? null, e.valorAtualBrl ?? null,
         e.moeda ?? 'BRL', JSON.stringify(e.dadosJson ?? {}),
       );
@@ -152,8 +173,27 @@ export const servicoPatrimonio = (bd: Bd) => {
     async atualizarItem(usuarioId: string, id: string, e: ItemPatrimonioAtualizarEntrada): Promise<ServiceResponse<ItemPatrimonioSaida>> {
       const atual = await repo.buscarItemBruto(usuarioId, id);
       if (!atual) return erro('item_nao_encontrado', 'Item de patrimônio não encontrado', 404);
+      let ativoId: string | null | undefined;
+      if (e.cnpj !== undefined) {
+        if (e.cnpj === null || e.cnpj.trim() === '') ativoId = null;
+        else {
+          const tipo = e.tipo ?? atual.tipo as TipoItemPatrimonio;
+          if (!aceitaCnpj(tipo)) return erro('cnpj_tipo_invalido', 'CNPJ só pode ser usado em fundos ou previdência', 400);
+          const cnpj = normalizarCnpjPatrimonial(e.cnpj);
+          if (!cnpj) return erro('cnpj_invalido', 'Informe um CNPJ com 14 dígitos', 400);
+          const existente = await repo.buscarAtivoPorCnpj(cnpj);
+          if (existente) ativoId = existente.id;
+          else {
+            await repo.inserirAtivoComCnpj(gerarId(), cnpj, tipo, e.nome ?? atual.nome);
+            const criado = await repo.buscarAtivoPorCnpj(cnpj);
+            if (!criado) return erro('ativo_nao_encontrado', 'Não foi possível vincular o CNPJ ao ativo', 500);
+            ativoId = criado.id;
+          }
+        }
+      }
       await repo.atualizarItem(id, usuarioId, {
         ...e,
+        ativoId,
         dadosJson: e.dadosJson !== undefined ? JSON.stringify(e.dadosJson) : undefined,
       });
       return this.obterItem(usuarioId, id);

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { servicoPatrimonio } from '../src/dominios/patrimonio/patrimonio.servico';
+
+test('vincula um fundo manual ao ativo canônico pelo CNPJ', async () => {
+  const execucoes: { sql: string; valores: unknown[] }[] = [];
+  let buscasAtivo = 0;
+  const bd = {
+    consultar: async () => [{
+      item_id: execucoes.at(-1)?.valores[0], usuario_id: 'usuario-1', tipo: 'fundo', origem: 'manual', nome: 'Fundo teste',
+      ativo_id: 'ativo-1', ticker: null, cnpj: '12345678000190', classe: null, subclasse: null,
+      quantidade: 1, preco_medio_brl: 10, valor_atual_brl: 10, preco_atual_brl: 10,
+      preco_atualizado_em: null, preco_fonte: null, rentabilidade_pct: null,
+      criado_em: '2026-07-25', atualizado_em: '2026-07-25',
+    }],
+    primeiro: async () => {
+      buscasAtivo += 1;
+      return buscasAtivo === 1 ? null : { id: execucoes[0].valores[0] as string };
+    },
+    executar: async (sql: string, ...valores: unknown[]) => {
+      execucoes.push({ sql, valores });
+      return { sucesso: true, linhasAfetadas: 1 };
+    },
+    emLote: async () => {},
+  };
+
+  const resultado = await servicoPatrimonio(bd).criarItem('usuario-1', {
+    tipo: 'fundo', nome: 'Fundo teste', cnpj: '12.345.678/0001-90', quantidade: 1, valorAtualBrl: 10,
+  });
+
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  assert.match(execucoes[0].sql, /INSERT INTO ativos/);
+  assert.equal(execucoes[0].valores[1], '12345678000190');
+  assert.match(execucoes[1].sql, /INSERT INTO patrimonio_itens/);
+  assert.equal(execucoes[1].valores[2], execucoes[0].valores[0]);
+});
+
+test('rejeita CNPJ fora de fundo ou previdência', async () => {
+  const bd = { consultar: async () => [], primeiro: async () => null, executar: async () => ({ sucesso: true, linhasAfetadas: 0 }), emLote: async () => {} };
+  const resultado = await servicoPatrimonio(bd).criarItem('usuario-1', {
+    tipo: 'acao', nome: 'Ação teste', cnpj: '12.345.678/0001-90',
+  });
+  assert.equal(resultado.ok, false);
+  assert.equal(resultado.codigo, 'cnpj_tipo_invalido');
+});


### PR DESCRIPTION
## O que mudou
- aceita CNPJ ao criar ou atualizar fundo/previdencia
- reutiliza ou cria o ativo no catalogo canônico e vincula o item patrimonial
- valida tipo e formato do CNPJ

## Por que
A Action CVM ja filtra por CNPJs vinculados ao patrimonio, mas nao existia um caminho para criar esse vinculo em itens manuais.

## Validacao
- npm.cmd run typecheck
- npm.cmd run test:api
- npm.cmd run build