### PR TITLE
Bloqueia deploy com validação falha

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,9 @@ jobs:
 
       - name: Run typecheck
         run: npm run typecheck
-        continue-on-error: true
+
+      - name: Run API tests
+        run: npm run test:api
 
       - name: Deploy Frontend to Cloudflare Pages
         run: npm run deploy:web


### PR DESCRIPTION
## O que mudou
- remove a tolerancia a erro do typecheck
- executa testes da API antes dos deploys Cloudflare

## Por que
A feature #110 exige que nenhum deploy avance com validacoes essenciais falhando.

## Validacao
- npm.cmd run typecheck
- npm.cmd run test:api
- npm.cmd run build