### PR TITLE
Explicita valor e frescor patrimonial

### DIFF
--- a/bibliotecas/contratos/patrimonio.ts
+++ b/bibliotecas/contratos/patrimonio.ts
@@ -5,6 +5,7 @@ export type TipoItemPatrimonio =
   | 'caixa' | 'poupanca' | 'imovel' | 'veiculo' | 'divida' | 'outro';
 
 export type OrigemItemPatrimonio = 'manual' | 'importacao' | 'vinculo_corretora' | 'sincronizado';
+export type EstadoValorPatrimonial = 'cotacao' | 'manual' | 'indisponivel';
 
 export type TipoAporte = 'aporte' | 'retirada' | 'transferencia' | 'ajuste';
 
@@ -23,6 +24,11 @@ export interface ItemPatrimonioSaida {
   precoMedioBrl: number | null;
   precoAtualBrl: number | null;
   valorAtualBrl: number | null;
+  estadoValor: EstadoValorPatrimonial;
+  fonteCotacao: string | null;
+  cotacaoAtualizadaEm: string | null;
+  cotacaoReferenciaEm: string | null;
+  cotacaoExpiraEm: string | null;
   rentabilidadePct: number | null;
   pesoPct: number | null;
   moeda: string;

--- a/documentacao/consolidacao/CONTRATO_PATRIMONIAL_CANONICO.md
+++ b/documentacao/consolidacao/CONTRATO_PATRIMONIAL_CANONICO.md
@@ -1,0 +1,25 @@
+# Contrato patrimonial canônico
+
+O Esquilo Wallet usa um único contrato para Home, Carteira, Histórico, Score e Vera. O catálogo público fica em `ativos`; a posição privada fica em `patrimonio_itens`; aportes e retiradas ficam em `patrimonio_aportes`.
+
+## Valor de um item
+
+1. Quando existem `quantidade` e cotação disponível, `valorAtualBrl = quantidade × precoAtualBrl`.
+2. Sem cotação calculável, o valor confirmado manualmente em `patrimonio_itens.valor_atual_brl` é mantido.
+3. Sem cotação nem valor manual, o estado é `indisponivel`; o produto não apresenta estimativa como dado atual.
+
+## Frescor e origem
+
+Cada item expõe `estadoValor`, `fonteCotacao`, `cotacaoAtualizadaEm`, `cotacaoReferenciaEm` e `cotacaoExpiraEm`.
+
+- `cotacao`: valor calculado pela cotação, com fonte e datas explícitas.
+- `manual`: último valor confirmado no item pelo usuário ou importação.
+- `indisponivel`: não há base suficiente para valorar o item.
+
+Para CVM, `cotacaoReferenciaEm` é a data da cota oficial; para BRAPI, ela é o instante de atualização da cotação. A expiração do cache é operacional e não substitui a data de referência do dado.
+
+## Regras de vínculo
+
+Fundos e previdência podem informar CNPJ. O backend normaliza o CNPJ, reutiliza ou cria o instrumento em `ativos` e o associa ao item patrimonial. A ingestão CVM consulta somente CNPJs de itens ativos vinculados dessa forma.
+
+Não há tabela paralela para catálogo, posição, cotação ou frescor.

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -30,6 +30,8 @@ export interface LinhaPosicao {
   preco_atual_brl: number | null;
   preco_atualizado_em: string | null;
   preco_fonte: string | null;
+  preco_referencia_em: string | null;
+  preco_expira_em: string | null;
   rentabilidade_pct: number | null;
   criado_em: string;
   atualizado_em: string;
@@ -138,7 +140,34 @@ export const repositorioPatrimonio = (bd: Bd) => ({
 
   async posicoes(usuarioId: string): Promise<LinhaPosicao[]> {
     return bd.consultar<LinhaPosicao>(
-      `SELECT * FROM vw_patrimonio_posicoes WHERE usuario_id = ? ORDER BY valor_atual_brl DESC, nome`,
+      `SELECT
+         i.id AS item_id, i.usuario_id, i.tipo, i.origem, i.nome, i.ativo_id,
+         a.ticker, a.cnpj, a.classe, a.subclasse, i.quantidade, i.preco_medio_brl,
+         COALESCE(c_cvm.preco_brl, c_brapi.preco_brl) AS preco_atual_brl,
+         COALESCE(c_cvm.cotado_em, c_brapi.cotado_em) AS preco_atualizado_em,
+         COALESCE(c_cvm.fonte, c_brapi.fonte) AS preco_fonte,
+         COALESCE(json_extract(c_cvm.dados_json, '$.referenciaEm'), json_extract(c_brapi.dados_json, '$.referenciaEm')) AS preco_referencia_em,
+         COALESCE(c_cvm.expira_em, c_brapi.expira_em) AS preco_expira_em,
+         CASE
+           WHEN i.quantidade IS NOT NULL AND COALESCE(c_cvm.preco_brl, c_brapi.preco_brl) IS NOT NULL
+             THEN i.quantidade * COALESCE(c_cvm.preco_brl, c_brapi.preco_brl)
+           ELSE i.valor_atual_brl
+         END AS valor_atual_brl,
+         CASE
+           WHEN i.preco_medio_brl IS NULL OR i.preco_medio_brl = 0 THEN NULL
+           WHEN COALESCE(c_cvm.preco_brl, c_brapi.preco_brl) IS NOT NULL
+             THEN ((COALESCE(c_cvm.preco_brl, c_brapi.preco_brl) - i.preco_medio_brl) / i.preco_medio_brl) * 100
+           WHEN i.valor_atual_brl IS NOT NULL AND i.quantidade IS NOT NULL AND i.quantidade <> 0
+             THEN (((i.valor_atual_brl / i.quantidade) - i.preco_medio_brl) / i.preco_medio_brl) * 100
+           ELSE NULL
+         END AS rentabilidade_pct,
+         i.criado_em, i.atualizado_em
+       FROM patrimonio_itens i
+       LEFT JOIN ativos a ON a.id = i.ativo_id
+       LEFT JOIN ativos_cotacoes_cache c_cvm ON c_cvm.ativo_id = i.ativo_id AND c_cvm.fonte = 'cvm'
+       LEFT JOIN ativos_cotacoes_cache c_brapi ON c_brapi.ativo_id = i.ativo_id AND c_brapi.fonte = 'brapi'
+       WHERE i.usuario_id = ? AND i.esta_ativo = 1
+       ORDER BY valor_atual_brl DESC, i.nome`,
       usuarioId,
     );
   },

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -19,6 +19,9 @@ import {
 const paraItemSaida = (l: LinhaPosicao, totalBrl: number): ItemPatrimonioSaida => {
   const valor = l.valor_atual_brl ?? 0;
   const peso = totalBrl > 0 ? (valor / totalBrl) * 100 : null;
+  const estadoValor = l.preco_atual_brl !== null && l.quantidade !== null
+    ? 'cotacao'
+    : l.valor_atual_brl !== null ? 'manual' : 'indisponivel';
   return {
     id: l.item_id,
     usuarioId: l.usuario_id,
@@ -34,6 +37,11 @@ const paraItemSaida = (l: LinhaPosicao, totalBrl: number): ItemPatrimonioSaida =
     precoMedioBrl: l.preco_medio_brl,
     precoAtualBrl: l.preco_atual_brl,
     valorAtualBrl: l.valor_atual_brl,
+    estadoValor,
+    fonteCotacao: l.preco_fonte,
+    cotacaoAtualizadaEm: l.preco_atualizado_em,
+    cotacaoReferenciaEm: l.preco_referencia_em ?? l.preco_atualizado_em,
+    cotacaoExpiraEm: l.preco_expira_em,
     rentabilidadePct: l.rentabilidade_pct,
     pesoPct: peso,
     moeda: 'BRL',

--- a/servidores/porta-entrada/src/jobs/mercado-atualizar.job.ts
+++ b/servidores/porta-entrada/src/jobs/mercado-atualizar.job.ts
@@ -39,26 +39,28 @@ export async function atualizarMercadoJob(env: Env): Promise<void> {
       ativo.id,
       fontePara(ativo.tipo),
       timestamp,
-      preco,
+      preco.valor,
       expira,
-      JSON.stringify({ origem: 'job', tipo: ativo.tipo }),
+      JSON.stringify({ origem: 'job', tipo: ativo.tipo, referenciaEm: preco.referenciaEm ?? timestamp }),
     );
   }
 }
 
 function fontePara(tipo: string): string {
-  if (tipo === 'fundo') return 'cvm';
+  if (tipo === 'fundo' || tipo === 'previdencia') return 'cvm';
   if (tipo === 'acao' || tipo === 'fii' || tipo === 'etf') return 'brapi';
   return 'manual';
 }
 
-async function buscarPreco(ativo: LinhaAtivoUsado, env: Env, bd: ReturnType<typeof criarBd>): Promise<number | null> {
-  if (ativo.tipo === 'fundo' && ativo.cnpj) {
-    const cota = await bd.primeiro<{ valor_cota: number }>(
-      `SELECT valor_cota FROM fundos_cvm_cotas WHERE cnpj = ? ORDER BY data DESC LIMIT 1`,
+async function buscarPreco(
+  ativo: LinhaAtivoUsado, env: Env, bd: ReturnType<typeof criarBd>,
+): Promise<{ valor: number; referenciaEm?: string } | null> {
+  if ((ativo.tipo === 'fundo' || ativo.tipo === 'previdencia') && ativo.cnpj) {
+    const cota = await bd.primeiro<{ valor_cota: number; data: string }>(
+      `SELECT valor_cota, data FROM fundos_cvm_cotas WHERE cnpj = ? ORDER BY data DESC LIMIT 1`,
       ativo.cnpj.replace(/\D/g, ''),
     );
-    return cota?.valor_cota ?? null;
+    return cota ? { valor: cota.valor_cota, referenciaEm: cota.data } : null;
   }
   if (ativo.ticker && (env.BRAPI_TOKEN || env.BRAPI_BASE_URL)) {
     const base = env.BRAPI_BASE_URL ?? 'https://brapi.dev/api';
@@ -68,7 +70,7 @@ async function buscarPreco(ativo: LinhaAtivoUsado, env: Env, bd: ReturnType<type
       if (!resp.ok) return null;
       const dados = await resp.json() as { results?: Array<{ regularMarketPrice?: number }> };
       const preco = dados.results?.[0]?.regularMarketPrice;
-      return typeof preco === 'number' ? preco : null;
+      return typeof preco === 'number' ? { valor: preco } : null;
     } catch {
       return null;
     }

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -43,3 +43,26 @@ test('rejeita CNPJ fora de fundo ou previdência', async () => {
   assert.equal(resultado.ok, false);
   assert.equal(resultado.codigo, 'cnpj_tipo_invalido');
 });
+
+test('expõe valor calculado e frescor da cotação no contrato patrimonial', async () => {
+  const bd = {
+    consultar: async () => [{
+      item_id: 'item-1', usuario_id: 'usuario-1', tipo: 'fundo', origem: 'manual', nome: 'Fundo teste',
+      ativo_id: 'ativo-1', ticker: null, cnpj: '12345678000190', classe: null, subclasse: null,
+      quantidade: 10, preco_medio_brl: 9, valor_atual_brl: 125, preco_atual_brl: 12.5,
+      preco_atualizado_em: '2026-07-25T10:00:00.000Z', preco_fonte: 'cvm',
+      preco_referencia_em: '2026-07-24', preco_expira_em: '2026-07-25T10:05:00.000Z',
+      rentabilidade_pct: 38.8, criado_em: '2026-07-25', atualizado_em: '2026-07-25',
+    }],
+    primeiro: async () => null,
+    executar: async () => ({ sucesso: true, linhasAfetadas: 0 }),
+    emLote: async () => {},
+  };
+  const resultado = await servicoPatrimonio(bd).listarItens('usuario-1');
+  assert.equal(resultado.ok, true);
+  if (!resultado.ok) return;
+  assert.deepEqual(resultado.dados.itens[0].estadoValor, 'cotacao');
+  assert.equal(resultado.dados.itens[0].valorAtualBrl, 125);
+  assert.equal(resultado.dados.itens[0].fonteCotacao, 'cvm');
+  assert.equal(resultado.dados.itens[0].cotacaoReferenciaEm, '2026-07-24');
+});


### PR DESCRIPTION
## O que mudou
- calcula o valor cotado por quantidade vezes cotacao
- lê cotacoes CVM e BRAPI no mesmo contrato canônico
- expõe fonte, atualizacao, referencia e expiracao da cotacao
- registra a data da cota CVM no cache e documenta as regras

## Por que
Fundos CVM eram ignorados na leitura patrimonial, e valor/frescor nao eram explicitos para os consumidores.

## Validacao
- npm.cmd run typecheck
- npm.cmd run test:api (7 testes)
- npm.cmd run build