### PR TITLE
Expõe frescor das cotações na carteira

### DIFF
--- a/apresentacao/src/features/carteira/AssetCategoryView.jsx
+++ b/apresentacao/src/features/carteira/AssetCategoryView.jsx
@@ -99,8 +99,12 @@ function adaptarItemCategoria(item, categoriaLegacy) {
     rentabilidadeDesdeAquisicaoPct: item.rentabilidadePct,
     rentabilidade_desde_aquisicao_pct: item.rentabilidadePct,
     rentabilidadeConfiavel: item.rentabilidadePct != null,
-    statusAtualizacao: item.precoAtualBrl != null ? "atualizado" : "indisponivel",
-    status_atualizacao: item.precoAtualBrl != null ? "atualizado" : "indisponivel",
+    estadoValor: item.estadoValor ?? (item.precoAtualBrl != null ? "cotacao" : "indisponivel"),
+    fonteCotacao: item.fonteCotacao ?? null,
+    cotacaoReferenciaEm: item.cotacaoReferenciaEm ?? null,
+    cotacaoAtualizadaEm: item.cotacaoAtualizadaEm ?? null,
+    statusAtualizacao: item.estadoValor === "manual" ? "manual" : item.precoAtualBrl != null ? "atualizado" : "indisponivel",
+    status_atualizacao: item.estadoValor === "manual" ? "manual" : item.precoAtualBrl != null ? "atualizado" : "indisponivel",
     statusPrecoMedio: "confiavel",
     plataforma: null,
     vencimento: null,
@@ -316,6 +320,16 @@ function StatusPrecoMedioBadge({ status }) {
   );
 }
 
+function TextoFrescor({ asset }) {
+  if (asset.estadoValor === "manual") return <p className="text-[10px] text-[#9A6A16] font-medium">Valor manual</p>;
+  if (asset.estadoValor === "indisponivel" || asset.precoAtual == null) return <p className="text-[10px] text-[#0B1218]/40 font-medium">Sem cotação</p>;
+  const fonte = asset.fonteCotacao ? asset.fonteCotacao.toUpperCase() : "Mercado";
+  const referencia = asset.cotacaoReferenciaEm ?? asset.cotacaoAtualizadaEm;
+  const data = referencia ? new Date(referencia.length === 10 ? `${referencia}T12:00:00` : referencia) : null;
+  const rotuloData = data && !Number.isNaN(data.getTime()) ? ` · ref. ${data.toLocaleDateString("pt-BR")}` : "";
+  return <p className="text-[10px] text-[#1A7A45] font-medium">{fonte}{rotuloData}</p>;
+}
+
 function AssetRow({ asset, categoria, ocultarValores, navigate }) {
   const valorAtual = asset.valorAtual ?? 0;
   const precoMedio = asset.precoMedio ?? asset.preco_medio ?? 0;
@@ -380,7 +394,7 @@ function AssetRow({ asset, categoria, ocultarValores, navigate }) {
             </div>
             <div>
               <p className="font-['Sora'] text-sm font-bold text-[#0B1218]">{asset.nome || asset.ticker}</p>
-              <p className="text-[10px] text-[#0B1218]/40 font-medium">Fundo de Investimento</p>
+              <TextoFrescor asset={asset} />
             </div>
           </div>
         </td>

--- a/apresentacao/src/features/carteira/Carteira.jsx
+++ b/apresentacao/src/features/carteira/Carteira.jsx
@@ -70,8 +70,12 @@ function adaptarItem(item) {
     rentabilidadeDesdeAquisicaoPct: item.rentabilidadePct,
     rentabilidade_desde_aquisicao_pct: item.rentabilidadePct,
     rentabilidadeConfiavel: item.rentabilidadePct != null,
-    statusAtualizacao: temCotacao ? "atualizado" : "indisponivel",
-    status_atualizacao: temCotacao ? "atualizado" : "indisponivel",
+    estadoValor: item.estadoValor ?? (temCotacao ? "cotacao" : "indisponivel"),
+    fonteCotacao: item.fonteCotacao ?? null,
+    cotacaoReferenciaEm: item.cotacaoReferenciaEm ?? null,
+    cotacaoAtualizadaEm: item.cotacaoAtualizadaEm ?? null,
+    statusAtualizacao: item.estadoValor === "manual" ? "manual" : temCotacao ? "atualizado" : "indisponivel",
+    status_atualizacao: item.estadoValor === "manual" ? "manual" : temCotacao ? "atualizado" : "indisponivel",
     statusPrecoMedio: "confiavel",
     plataforma: "N/A",
   };
@@ -112,6 +116,24 @@ const calcularValorAplicado = (asset) => {
   const qtd = Number(asset?.quantidade ?? 0);
   const preco = Number(asset?.precoMedio ?? asset?.preco_medio ?? 0);
   return qtd > 0 && preco > 0 ? qtd * preco : Number(asset?.valorAtual ?? asset?.valor ?? 0);
+};
+
+const formatarReferencia = (valor) => {
+  if (!valor) return null;
+  const data = new Date(valor.length === 10 ? `${valor}T12:00:00` : valor);
+  return Number.isNaN(data.getTime()) ? null : data.toLocaleDateString("pt-BR");
+};
+
+const RotuloFrescor = ({ asset }) => {
+  if (asset.estadoValor === "manual" || asset.statusAtualizacao === "manual") {
+    return <p className="text-[10px] text-[#9A6A16] font-medium mt-1">Valor confirmado manualmente</p>;
+  }
+  if (asset.estadoValor === "indisponivel" || !asset.precoAtual) {
+    return <p className="text-[10px] text-[#0B1218]/40 font-medium mt-1">Sem cotação disponível</p>;
+  }
+  const fonte = asset.fonteCotacao ? asset.fonteCotacao.toUpperCase() : "Mercado";
+  const referencia = formatarReferencia(asset.cotacaoReferenciaEm ?? asset.cotacaoAtualizadaEm);
+  return <p className="text-[10px] text-[#1A7A45] font-medium mt-1">{fonte}{referencia ? ` · ref. ${referencia}` : ""}</p>;
 };
 
 const TooltipDonut = ({ active, payload, ocultarValores = false }) => {
@@ -349,6 +371,7 @@ const AssetCard = ({ asset, navigate, ocultarValores = false }) => {
         <div>
           <p className="font-['Sora'] text-base font-bold text-[#0B1218]">{asset.ticker}</p>
           <p className="text-[10px] text-[#0B1218]/40 font-medium truncate max-w-[160px]">{asset.nome}</p>
+          <RotuloFrescor asset={asset} />
         </div>
         {perc != null ? (
           <div className={`flex items-center gap-0.5 text-[11px] font-bold ${corRetorno}`}>
@@ -452,7 +475,10 @@ const AssetRow = React.memo(({ asset, categoria, navigate, ocultarValores, isLas
   if (isFundoOuRendaFixa) {
     return (
       <tr className={`${rowBorderClass} hover:bg-[#FAFAFA] transition-colors`}>
-        <td className="py-4 px-4 text-sm font-semibold">{asset.nome || asset.ticker}</td>
+        <td className="py-4 px-4 text-sm font-semibold">
+          <span>{asset.nome || asset.ticker}</span>
+          <RotuloFrescor asset={asset} />
+        </td>
         <td className="py-4 px-4 text-sm">{ocultarValores ? "••••••••" : moeda(valorAtual)}</td>
         <td className="py-4 px-4 text-sm">{ocultarValores ? "••••••••" : `${(asset.participacao ?? 0).toFixed(2)}%`}</td>
         <td className="py-4 px-4 text-sm">{ocultarValores ? "••••••••" : (rentabilidadeIndisponivel ? "—" : `${rentabilidade >= 0 ? "+" : ""}${rentabilidade.toFixed(2)}%`)}</td>

--- a/apresentacao/src/features/home/Home.jsx
+++ b/apresentacao/src/features/home/Home.jsx
@@ -69,6 +69,22 @@ const TIPO_LABELS = {
 
 const getTipoLabel = (tipo) => TIPO_LABELS[tipo] || 'Outros';
 
+const textoFrescorAtivo = (ativo) => {
+  if (ativo?.estadoValor === 'manual') return 'Valor manual';
+  if (ativo?.estadoValor === 'indisponivel' || ativo?.precoAtualBrl == null) {
+    return 'Sem cotação';
+  }
+
+  const fonte = ativo.fonteCotacao ? ativo.fonteCotacao.toUpperCase() : 'Mercado';
+  const referencia = ativo.cotacaoReferenciaEm ?? ativo.cotacaoAtualizadaEm;
+  if (!referencia) return fonte;
+
+  const data = new Date(referencia.length === 10 ? `${referencia}T12:00:00` : referencia);
+  return Number.isNaN(data.getTime())
+    ? fonte
+    : `${fonte} · ref. ${data.toLocaleDateString('pt-BR')}`;
+};
+
 /**
  * Converte avaliação (% vs benchmark) em classificação qualitativa
  * BOM: >= 5%, NEUTRO: -5% a 5%, RUIM: < -5%
@@ -735,6 +751,7 @@ export default function HomeLobby() {
                             <div className="min-w-0">
                               <p className="text-sm font-semibold truncate">{ativo.nome}</p>
                               <p className="text-[11px] text-[var(--text-muted)] truncate">{ativo.ticker}</p>
+                              <p className="text-[10px] text-[var(--text-muted)] truncate">{textoFrescorAtivo(ativo)}</p>
                             </div>
                             {/* VALOR ATUAL */}
                             <p className="text-sm font-semibold text-center self-center whitespace-nowrap">
@@ -792,12 +809,13 @@ export default function HomeLobby() {
                         const r = rentabilidadePct(ativo);
                         return (
                           <button key={ativo.id} onClick={() => navigate(`/ativo/${ativo.ticker}`)}
-                            className="w-full grid gap-2 px-2 py-2.5 rounded-lg hover:bg-[var(--bg-secondary)] transition-colors text-left h-12"
+                            className="w-full grid gap-2 px-2 py-2.5 rounded-lg hover:bg-[var(--bg-secondary)] transition-colors text-left"
                             style={{ gridTemplateColumns: '1fr 72px 60px 40px' }}>
                             {/* ATIVO */}
                             <div className="min-w-0">
                               <p className="text-sm font-semibold truncate">{ativo.ticker}</p>
                               <p className="text-[11px] text-[var(--text-muted)] truncate">{ativo.nome}</p>
+                              <p className="text-[10px] text-[var(--text-muted)] truncate">{textoFrescorAtivo(ativo)}</p>
                             </div>
                             {/* VALOR ATUAL */}
                             <p className="text-sm font-semibold text-center self-center whitespace-nowrap">


### PR DESCRIPTION
## O que mudou
- mostra a fonte e a data de referência da cotação na Carteira e na Home;
- diferencia valor manual, cotação disponível e cotação indisponível;
- aplica a indicação também à lista de fundos.

## Por quê
O contrato patrimonial canônico já fornece estado, fonte e frescor da cotação. Esta PR evita que a interface apresente esses valores como se fossem equivalentes.

## Validação
- 
pm.cmd run typecheck
- 
pm.cmd run test:api (7 testes)
- 
pm.cmd run build

A inspeção visual autenticada não pôde ser executada: o navegador integrado bloqueou o acesso ao servidor local com 
et::ERR_BLOCKED_BY_CLIENT.