### PR TITLE
Garante idempotência dos lotes de importação

### DIFF
--- a/infra/banco/migrations/101_importacoes_idempotentes.sql
+++ b/infra/banco/migrations/101_importacoes_idempotentes.sql
@@ -1,0 +1,9 @@
+-- Incremental e seguro sobre o schema canônico já existente.
+-- Não use `wrangler d1 migrations apply` sem antes baselinar a migration 100
+-- no D1 remoto: ela é um rebuild histórico e contém DROP TABLE.
+
+ALTER TABLE importacoes ADD COLUMN chave_idempotencia TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_importacoes_usuario_chave_idempotencia
+  ON importacoes(usuario_id, chave_idempotencia)
+  WHERE chave_idempotencia IS NOT NULL;

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -292,10 +292,18 @@ export const repositorioPatrimonio = (bd: Bd) => ({
     );
   },
 
-  async inserirImportacao(id: string, usuarioId: string, origem: string): Promise<void> {
+  async inserirImportacao(id: string, usuarioId: string, origem: string, chaveIdempotencia: string): Promise<void> {
     await bd.executar(
-      `INSERT INTO importacoes (id, usuario_id, origem, status) VALUES (?, ?, ?, 'pendente')`,
-      id, usuarioId, origem,
+      `INSERT INTO importacoes (id, usuario_id, origem, status, chave_idempotencia) VALUES (?, ?, ?, 'pendente', ?)`,
+      id, usuarioId, origem, chaveIdempotencia,
+    );
+  },
+
+  async buscarImportacaoPorChave(usuarioId: string, chaveIdempotencia: string) {
+    return bd.primeiro<LinhaImportacao>(
+      `SELECT id, usuario_id, origem, status, iniciado_em, concluido_em
+         FROM importacoes WHERE usuario_id = ? AND chave_idempotencia = ? LIMIT 1`,
+      usuarioId, chaveIdempotencia,
     );
   },
 

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -91,6 +91,23 @@ const normalizarCnpjPatrimonial = (valor: string): string | null => {
 
 const aceitaCnpj = (tipo: TipoItemPatrimonio): boolean => tipo === 'fundo' || tipo === 'previdencia';
 
+const serializarEstavel = (valor: unknown): string => {
+  if (Array.isArray(valor)) return `[${valor.map(serializarEstavel).join(',')}]`;
+  if (valor && typeof valor === 'object') {
+    const entradas = Object.entries(valor as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([chave, item]) => `${JSON.stringify(chave)}:${serializarEstavel(item)}`);
+    return `{${entradas.join(',')}}`;
+  }
+  return JSON.stringify(valor);
+};
+
+const chaveIdempotenciaImportacao = async (itens: ImportacaoCriarEntrada['itens']): Promise<string> => {
+  const conteudo = serializarEstavel(itens.map(({ linha, tipo, dadosJson }) => ({ linha, tipo, dadosJson })));
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(conteudo));
+  return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+};
+
 export const servicoPatrimonio = (bd: Bd) => {
   const repo = repositorioPatrimonio(bd);
 
@@ -275,8 +292,11 @@ export const servicoPatrimonio = (bd: Bd) => {
 
     async criarImportacao(usuarioId: string, e: ImportacaoCriarEntrada): Promise<ServiceResponse<ImportacaoSaida>> {
       if (!e.origem || !Array.isArray(e.itens)) return erro('dados_incompletos', 'origem e itens são obrigatórios', 400);
+      const chaveIdempotencia = await chaveIdempotenciaImportacao(e.itens);
+      const existente = await repo.buscarImportacaoPorChave(usuarioId, chaveIdempotencia);
+      if (existente) return this.obterImportacao(usuarioId, existente.id);
       const id = gerarId();
-      await repo.inserirImportacao(id, usuarioId, e.origem);
+      await repo.inserirImportacao(id, usuarioId, e.origem, chaveIdempotencia);
       for (const item of e.itens) {
         await repo.inserirItemImportacao(
           gerarId(), id, item.linha, item.tipo, JSON.stringify(item.dadosJson ?? {}),

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -44,6 +44,41 @@ test('rejeita CNPJ fora de fundo ou previdência', async () => {
   assert.equal(resultado.codigo, 'cnpj_tipo_invalido');
 });
 
+test('reenvio do mesmo lote reutiliza a importação sem gravar linhas novamente', async () => {
+  const importacoes = new Map<string, { id: string; usuario_id: string; origem: string; status: string; iniciado_em: string; concluido_em: null; chave: string }>();
+  let itensInseridos = 0;
+  const bd = {
+    consultar: async () => [],
+    primeiro: async (_sql: string, ...valores: unknown[]) => {
+      const [primeiro, segundo] = valores;
+      if (_sql.includes('chave_idempotencia')) {
+        return [...importacoes.values()].find((importacao) => importacao.usuario_id === primeiro && importacao.chave === segundo) ?? null;
+      }
+      return importacoes.get(primeiro as string) ?? null;
+    },
+    executar: async (sql: string, ...valores: unknown[]) => {
+      if (sql.includes('INSERT INTO importacoes')) {
+        const [id, usuarioId, origem, chave] = valores as string[];
+        importacoes.set(id, { id, usuario_id: usuarioId, origem, status: 'pendente', iniciado_em: '2026-07-26', concluido_em: null, chave });
+      }
+      if (sql.includes('INSERT INTO importacao_itens')) itensInseridos += 1;
+      return { sucesso: true, linhasAfetadas: 1 };
+    },
+    emLote: async () => {},
+  };
+  const servico = servicoPatrimonio(bd);
+  const entrada = { origem: 'carteira.xlsx', itens: [{ linha: 1, tipo: 'desconhecido', dadosJson: { aba: 'acoes', ticker: 'PETR4', quantidade: 10 } }] };
+
+  const primeiro = await servico.criarImportacao('usuario-1', entrada);
+  const segundo = await servico.criarImportacao('usuario-1', entrada);
+
+  assert.equal(primeiro.ok, true, JSON.stringify(primeiro));
+  assert.equal(segundo.ok, true, JSON.stringify(segundo));
+  if (!primeiro.ok || !segundo.ok) return;
+  assert.equal(segundo.dados.id, primeiro.dados.id);
+  assert.equal(itensInseridos, 1);
+});
+
 test('expõe valor calculado e frescor da cotação no contrato patrimonial', async () => {
   const bd = {
     consultar: async () => [{


### PR DESCRIPTION
## O que mudou
- gera uma chave SHA-256 estável a partir das linhas do lote;
- reutiliza o lote do mesmo usuário quando o conteúdo é reenviado;
- adiciona índice único parcial no D1 e teste de caracterização.

## Por quê
O pipeline de importação precisa rejeitar reenvios do mesmo lote antes da futura etapa de materialização das posições.

## Operação D1
A migration 100 foi baselinada no banco existente e a migration 101, estritamente aditiva, foi aplicada e verificada. O rebuild histórico não foi executado.

## Validação
- npm.cmd run test:api (8 testes)
- npm.cmd run build