### PR TITLE
Confirma importação em lote atômico

### DIFF
--- a/apresentacao/src/cliente-api/patrimonio.ts
+++ b/apresentacao/src/cliente-api/patrimonio.ts
@@ -9,6 +9,7 @@ import type {
   PatrimonioScoreSaida,
   ImportacaoSaida,
   ImportacaoCriarEntrada,
+  ImportacaoConfirmarSaida,
 } from "@ei/contratos";
 import { apiRequest } from "./http";
 
@@ -78,4 +79,10 @@ export function criarImportacao(entrada: ImportacaoCriarEntrada): Promise<Import
 
 export function obterImportacao(id: string): Promise<ImportacaoSaida> {
   return apiRequest<ImportacaoSaida>(`/api/patrimonio/importacoes/${encodeURIComponent(id)}`, { method: "GET" });
+}
+
+export function confirmarImportacao(id: string): Promise<ImportacaoConfirmarSaida> {
+  return apiRequest<ImportacaoConfirmarSaida>(`/api/patrimonio/importacoes/${encodeURIComponent(id)}/confirmar`, {
+    method: "POST",
+  });
 }

--- a/apresentacao/src/features/importacao/Importar.jsx
+++ b/apresentacao/src/features/importacao/Importar.jsx
@@ -168,14 +168,12 @@ export default function Importar({ embedded = false }) {
       const linhasValidas = (preview.itens ?? [])
         .filter((item) => item.status === 'ok')
         .map((item) => item.linha);
-      // Backend canônico já ingere os itens na criação; confirmação é apenas
-      // sinalização local + telemetria.
-      await patrimonioApi.obterImportacao(preview.importacaoId).catch(() => null);
+      const confirmacao = await patrimonioApi.confirmarImportacao(preview.importacaoId);
       await telemetriaApi.registrarEvento({
         nome: 'import_confirmed',
         dadosJson: {
           importacaoId: preview.importacaoId,
-          itensValidos: linhasValidas.length,
+          itensValidos: confirmacao.itensCriados,
         },
       }).catch(() => null);
       invalidarCacheUsuario();
@@ -184,7 +182,7 @@ export default function Importar({ embedded = false }) {
         replace: true,
         state: {
           showSuccessImport: true,
-          importedItems: linhasValidas.length,
+          importedItems: confirmacao.itensCriados,
           importacaoId: preview.importacaoId,
         },
       });

--- a/apresentacao/src/features/importacao/ImportarMobile.jsx
+++ b/apresentacao/src/features/importacao/ImportarMobile.jsx
@@ -81,16 +81,16 @@ export default function ImportarMobile() {
     if (!preview || isConfirmando) return;
     setIsConfirmando(true);
     try {
-      await patrimonioApi.obterImportacao(preview.importacaoId).catch(() => null);
+      const confirmacao = await patrimonioApi.confirmarImportacao(preview.importacaoId);
       await telemetriaApi.registrarEvento({
         nome: 'import_confirmed',
-        dadosJson: { importacaoId: preview.importacaoId, itensValidos: preview.totalItens },
+        dadosJson: { importacaoId: preview.importacaoId, itensValidos: confirmacao.itensCriados },
       }).catch(() => null);
       invalidarCacheUsuario();
       localStorage.setItem('hasSeenPreInsight', 'true');
       navigate('/home', {
         replace: true,
-        state: { showSuccessImport: true, importedItems: preview.totalItens, importacaoId: preview.importacaoId },
+        state: { showSuccessImport: true, importedItems: confirmacao.itensCriados, importacaoId: preview.importacaoId },
       });
     } catch {
       setErro('Falha ao confirmar. Tente novamente.');

--- a/bibliotecas/contratos/patrimonio.ts
+++ b/bibliotecas/contratos/patrimonio.ts
@@ -155,3 +155,9 @@ export interface ImportacaoItemEntrada {
   tipo: string;
   dadosJson: Record<string, unknown>;
 }
+
+export interface ImportacaoConfirmarSaida {
+  importacao: ImportacaoSaida;
+  itensCriados: number;
+  itensRejeitados: number;
+}

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -117,6 +117,14 @@ export interface LinhaImportacao {
   concluido_em: string | null;
 }
 
+export interface LinhaItemImportacao {
+  id: string;
+  linha: number;
+  tipo: string;
+  resultado: string;
+  dados_json: string;
+}
+
 export const repositorioPatrimonio = (bd: Bd) => ({
   async buscarAtivoPorCnpj(cnpj: string) {
     return bd.primeiro<{ id: string }>(`SELECT id FROM ativos WHERE cnpj = ? LIMIT 1`, cnpj);
@@ -320,5 +328,49 @@ export const repositorioPatrimonio = (bd: Bd) => ({
          FROM importacoes WHERE id = ? AND usuario_id = ? LIMIT 1`,
       id, usuarioId,
     );
+  },
+
+  async listarItensImportacao(importacaoId: string): Promise<LinhaItemImportacao[]> {
+    return bd.consultar<LinhaItemImportacao>(
+      `SELECT id, linha, tipo, resultado, dados_json
+         FROM importacao_itens WHERE importacao_id = ? ORDER BY linha ASC`,
+      importacaoId,
+    );
+  },
+
+  async reservarImportacao(id: string, usuarioId: string): Promise<boolean> {
+    const resultado = await bd.executar(
+      `UPDATE importacoes SET status = 'validado'
+         WHERE id = ? AND usuario_id = ? AND status IN ('pendente', 'falhou')`,
+      id, usuarioId,
+    );
+    return resultado.linhasAfetadas === 1;
+  },
+
+  async concluirImportacao(id: string, usuarioId: string): Promise<void> {
+    await bd.executar(
+      `UPDATE importacoes SET status = 'confirmado', concluido_em = datetime('now')
+         WHERE id = ? AND usuario_id = ?`,
+      id, usuarioId,
+    );
+  },
+
+  async falharImportacao(id: string, usuarioId: string): Promise<void> {
+    await bd.executar(
+      `UPDATE importacoes SET status = 'falhou' WHERE id = ? AND usuario_id = ?`,
+      id, usuarioId,
+    );
+  },
+
+  async resumoItensImportacao(importacaoId: string): Promise<{ aceitos: number; rejeitados: number }> {
+    const linhas = await bd.consultar<{ resultado: string; quantidade: number }>(
+      `SELECT resultado, COUNT(*) AS quantidade FROM importacao_itens
+         WHERE importacao_id = ? GROUP BY resultado`,
+      importacaoId,
+    );
+    return {
+      aceitos: linhas.find((linha) => linha.resultado === 'aceito')?.quantidade ?? 0,
+      rejeitados: linhas.find((linha) => linha.resultado === 'rejeitado')?.quantidade ?? 0,
+    };
   },
 });

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.rotas.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.rotas.ts
@@ -45,6 +45,8 @@ export async function rotearPatrimonio(
   }
   const mImp = caminho.match(/^\/api\/patrimonio\/importacoes\/([^/]+)$/);
   if (mImp && metodo === 'GET') return servico.obterImportacao(sessao.usuarioId, mImp[1]);
+  const mConfirmarImportacao = caminho.match(/^\/api\/patrimonio\/importacoes\/([^/]+)\/confirmar$/);
+  if (mConfirmarImportacao && metodo === 'POST') return servico.confirmarImportacao(sessao.usuarioId, mConfirmarImportacao[1]);
 
   return caminho.startsWith('/api/patrimonio') ? naoEncontrado() : metodoNaoPermitido(metodo);
 }

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -5,7 +5,7 @@ import type {
   PatrimonioResumoSaida, AlocacaoClasse,
   PatrimonioScoreSaida, ScoreFaixa, ScorePilar,
   TipoItemPatrimonio, OrigemItemPatrimonio,
-  ImportacaoSaida, ImportacaoCriarEntrada,
+  ImportacaoSaida, ImportacaoCriarEntrada, ImportacaoConfirmarSaida,
 } from '@ei/contratos';
 import type { Bd } from '../../infra/bd';
 import { gerarId } from '../../infra/bd';
@@ -106,6 +106,54 @@ const chaveIdempotenciaImportacao = async (itens: ImportacaoCriarEntrada['itens'
   const conteudo = serializarEstavel(itens.map(({ linha, tipo, dadosJson }) => ({ linha, tipo, dadosJson })));
   const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(conteudo));
   return Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('');
+};
+
+type ItemImportado = {
+  tipo: TipoItemPatrimonio;
+  nome: string;
+  quantidade: number | null;
+  precoMedioBrl: number | null;
+  valorAtualBrl: number | null;
+  dadosJson: string;
+};
+
+const numeroPositivo = (valor: unknown): number | null => {
+  const numero = typeof valor === 'number' ? valor : Number(valor);
+  return Number.isFinite(numero) && numero > 0 ? numero : null;
+};
+
+const textoObrigatorio = (valor: unknown): string | null => {
+  const texto = typeof valor === 'string' ? valor.trim() : '';
+  return texto || null;
+};
+
+const materializarItemImportado = (dados: Record<string, unknown>): ItemImportado | null => {
+  const aba = textoObrigatorio(dados.aba);
+  const bruto = JSON.stringify(dados);
+  if (aba === 'acoes') {
+    const ticker = textoObrigatorio(dados.ticker);
+    const quantidade = numeroPositivo(dados.quantidade);
+    if (!ticker || !quantidade) return null;
+    const precoMedioBrl = numeroPositivo(dados.precoMedio);
+    const valorAtualBrl = numeroPositivo(dados.valorTotal) ?? (precoMedioBrl ? quantidade * precoMedioBrl : null);
+    return { tipo: 'acao', nome: textoObrigatorio(dados.nome) ?? ticker, quantidade, precoMedioBrl, valorAtualBrl, dadosJson: bruto };
+  }
+  const mapeamento: Record<string, TipoItemPatrimonio> = {
+    fundos: 'fundo', previdencia: 'previdencia', renda_fixa: 'renda_fixa',
+    imoveis: 'imovel', veiculos: 'veiculo', poupanca: 'poupanca',
+  };
+  const tipo = aba ? mapeamento[aba] : undefined;
+  if (!tipo) return null;
+  const nome = textoObrigatorio(dados.nome)
+    ?? textoObrigatorio(dados.descricao)
+    ?? textoObrigatorio(dados.instituicao)
+    ?? (tipo === 'veiculo' ? [textoObrigatorio(dados.montadora), textoObrigatorio(dados.modelo)].filter(Boolean).join(' ') : null);
+  const valorAtualBrl = numeroPositivo(dados.valorAplicado)
+    ?? numeroPositivo(dados.valorEstimado)
+    ?? numeroPositivo(dados.valorReferencia)
+    ?? numeroPositivo(dados.valorAtual);
+  if (!nome || !valorAtualBrl) return null;
+  return { tipo, nome, quantidade: null, precoMedioBrl: null, valorAtualBrl, dadosJson: bruto };
 };
 
 export const servicoPatrimonio = (bd: Bd) => {
@@ -316,6 +364,59 @@ export const servicoPatrimonio = (bd: Bd) => {
         iniciadoEm: l.iniciado_em,
         concluidoEm: l.concluido_em,
       });
+    },
+
+    async confirmarImportacao(usuarioId: string, id: string): Promise<ServiceResponse<ImportacaoConfirmarSaida>> {
+      const importacao = await repo.buscarImportacao(id, usuarioId);
+      if (!importacao) return erro('importacao_nao_encontrada', 'Importação não encontrada', 404);
+      const resumoExistente = await repo.resumoItensImportacao(id);
+      if (importacao.status === 'confirmado') {
+        const existente = await this.obterImportacao(usuarioId, id);
+        if (!existente.ok) return existente;
+        return sucesso({ importacao: existente.dados, itensCriados: resumoExistente.aceitos, itensRejeitados: resumoExistente.rejeitados });
+      }
+      if (!(await repo.reservarImportacao(id, usuarioId))) {
+        return erro('importacao_em_processamento', 'Importação já está sendo confirmada', 409);
+      }
+
+      try {
+        const linhas = await repo.listarItensImportacao(id);
+        const operacoes: { sql: string; valores: unknown[] }[] = [];
+        const chavesLinhas = new Set<string>();
+        let aceitos = 0;
+        let rejeitados = 0;
+        for (const linha of linhas) {
+          let dados: Record<string, unknown> | null = null;
+          try { dados = JSON.parse(linha.dados_json) as Record<string, unknown>; } catch { dados = null; }
+          const item = dados ? materializarItemImportado(dados) : null;
+          const chaveLinha = item ? serializarEstavel({
+            tipo: item.tipo, nome: item.nome.toLocaleUpperCase('pt-BR'), quantidade: item.quantidade,
+            precoMedioBrl: item.precoMedioBrl, valorAtualBrl: item.valorAtualBrl,
+          }) : null;
+          if (!item || !chaveLinha || chavesLinhas.has(chaveLinha)) {
+            rejeitados += 1;
+            operacoes.push({ sql: `UPDATE importacao_itens SET resultado = 'rejeitado' WHERE id = ?`, valores: [linha.id] });
+            continue;
+          }
+          chavesLinhas.add(chaveLinha);
+          aceitos += 1;
+          operacoes.push({
+            sql: `INSERT INTO patrimonio_itens
+                    (id, usuario_id, tipo, origem, nome, quantidade, preco_medio_brl, valor_atual_brl, moeda, dados_json)
+                  VALUES (?, ?, ?, 'importacao', ?, ?, ?, ?, 'BRL', ?)`,
+            valores: [gerarId(), usuarioId, item.tipo, item.nome, item.quantidade, item.precoMedioBrl, item.valorAtualBrl, item.dadosJson],
+          });
+          operacoes.push({ sql: `UPDATE importacao_itens SET resultado = 'aceito' WHERE id = ?`, valores: [linha.id] });
+        }
+        await bd.emLote(operacoes);
+        await repo.concluirImportacao(id, usuarioId);
+        const confirmada = await this.obterImportacao(usuarioId, id);
+        if (!confirmada.ok) return confirmada;
+        return sucesso({ importacao: confirmada.dados, itensCriados: aceitos, itensRejeitados: rejeitados });
+      } catch (causa) {
+        await repo.falharImportacao(id, usuarioId);
+        throw causa;
+      }
     },
   };
 };

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -79,6 +79,36 @@ test('reenvio do mesmo lote reutiliza a importação sem gravar linhas novamente
   assert.equal(itensInseridos, 1);
 });
 
+test('confirma um lote criando a posição canônica uma única vez', async () => {
+  const lotes: { sql: string; valores: unknown[] }[][] = [];
+  const importacao = {
+    id: 'importacao-1', usuario_id: 'usuario-1', origem: 'carteira.xlsx', status: 'pendente',
+    iniciado_em: '2026-07-26', concluido_em: null,
+  };
+  const bd = {
+    consultar: async (sql: string) => {
+      if (sql.includes('FROM importacao_itens') && sql.includes('ORDER BY linha')) {
+        return [{ id: 'linha-1', linha: 1, tipo: 'desconhecido', resultado: 'pendente', dados_json: JSON.stringify({
+          aba: 'acoes', ticker: 'PETR4', nome: 'Petrobras PN', quantidade: 10, precoMedio: 30, valorTotal: 320,
+        }) }];
+      }
+      return [];
+    },
+    primeiro: async () => importacao,
+    executar: async () => ({ sucesso: true, linhasAfetadas: 1 }),
+    emLote: async (operacoes: { sql: string; valores: unknown[] }[]) => { lotes.push(operacoes); },
+  };
+
+  const resultado = await servicoPatrimonio(bd).confirmarImportacao('usuario-1', 'importacao-1');
+
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  if (!resultado.ok) return;
+  assert.equal(resultado.dados.itensCriados, 1);
+  assert.equal(resultado.dados.itensRejeitados, 0);
+  assert.match(lotes[0][0].sql, /INSERT INTO patrimonio_itens/);
+  assert.match(lotes[0][1].sql, /resultado = 'aceito'/);
+});
+
 test('expõe valor calculado e frescor da cotação no contrato patrimonial', async () => {
   const bd = {
     consultar: async () => [{


### PR DESCRIPTION
## O que mudou
- adiciona confirmação explícita do lote de importação;
- cria posições patrimoniais e atualiza o resultado das linhas no mesmo lote D1;
- rejeita linhas inválidas e duplicadas dentro do arquivo;
- torna confirmação repetida idempotente e atualiza desktop/mobile somente após sucesso.

## Por quê
A tela anterior informava sucesso sem materializar o patrimônio. Agora a confirmação é a única etapa que efetiva as posições.

## Validação
- npm.cmd run typecheck
- npm.cmd run test:api (9 testes)
- npm.cmd run build