### PR TITLE
Vincula CNPJ na confirmação de importação

### DIFF
--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -111,6 +111,7 @@ const chaveIdempotenciaImportacao = async (itens: ImportacaoCriarEntrada['itens'
 type ItemImportado = {
   tipo: TipoItemPatrimonio;
   nome: string;
+  cnpj: string | null;
   quantidade: number | null;
   precoMedioBrl: number | null;
   valorAtualBrl: number | null;
@@ -136,7 +137,7 @@ const materializarItemImportado = (dados: Record<string, unknown>): ItemImportad
     if (!ticker || !quantidade) return null;
     const precoMedioBrl = numeroPositivo(dados.precoMedio);
     const valorAtualBrl = numeroPositivo(dados.valorTotal) ?? (precoMedioBrl ? quantidade * precoMedioBrl : null);
-    return { tipo: 'acao', nome: textoObrigatorio(dados.nome) ?? ticker, quantidade, precoMedioBrl, valorAtualBrl, dadosJson: bruto };
+    return { tipo: 'acao', nome: textoObrigatorio(dados.nome) ?? ticker, cnpj: null, quantidade, precoMedioBrl, valorAtualBrl, dadosJson: bruto };
   }
   const mapeamento: Record<string, TipoItemPatrimonio> = {
     fundos: 'fundo', previdencia: 'previdencia', renda_fixa: 'renda_fixa',
@@ -153,7 +154,9 @@ const materializarItemImportado = (dados: Record<string, unknown>): ItemImportad
     ?? numeroPositivo(dados.valorReferencia)
     ?? numeroPositivo(dados.valorAtual);
   if (!nome || !valorAtualBrl) return null;
-  return { tipo, nome, quantidade: null, precoMedioBrl: null, valorAtualBrl, dadosJson: bruto };
+  const cnpjBruto = textoObrigatorio(dados.cnpj);
+  const cnpj = cnpjBruto && aceitaCnpj(tipo) ? normalizarCnpjPatrimonial(cnpjBruto) : null;
+  return { tipo, nome, cnpj, quantidade: null, precoMedioBrl: null, valorAtualBrl, dadosJson: bruto };
 };
 
 export const servicoPatrimonio = (bd: Bd) => {
@@ -383,6 +386,9 @@ export const servicoPatrimonio = (bd: Bd) => {
         const linhas = await repo.listarItensImportacao(id);
         const operacoes: { sql: string; valores: unknown[] }[] = [];
         const chavesLinhas = new Set<string>();
+        const ativosPorCnpj = new Map<string, string>();
+        const ativosNovos: { id: string; cnpj: string; tipo: TipoItemPatrimonio; nome: string }[] = [];
+        const itensAceitos: { linhaId: string; item: ItemImportado }[] = [];
         let aceitos = 0;
         let rejeitados = 0;
         for (const linha of linhas) {
@@ -400,13 +406,33 @@ export const servicoPatrimonio = (bd: Bd) => {
           }
           chavesLinhas.add(chaveLinha);
           aceitos += 1;
+          itensAceitos.push({ linhaId: linha.id, item });
+        }
+        for (const { item } of itensAceitos) {
+          if (!item.cnpj || ativosPorCnpj.has(item.cnpj)) continue;
+          const existente = await repo.buscarAtivoPorCnpj(item.cnpj);
+          if (existente) ativosPorCnpj.set(item.cnpj, existente.id);
+          else {
+            const ativoId = gerarId();
+            ativosPorCnpj.set(item.cnpj, ativoId);
+            ativosNovos.push({ id: ativoId, cnpj: item.cnpj, tipo: item.tipo, nome: item.nome });
+          }
+        }
+        for (const ativo of ativosNovos) {
+          operacoes.push({
+            sql: `INSERT INTO ativos (id, cnpj, nome, tipo) VALUES (?, ?, ?, ?)`,
+            valores: [ativo.id, ativo.cnpj, ativo.nome, ativo.tipo],
+          });
+        }
+        for (const { linhaId, item } of itensAceitos) {
+          const ativoId = item.cnpj ? ativosPorCnpj.get(item.cnpj) ?? null : null;
           operacoes.push({
             sql: `INSERT INTO patrimonio_itens
-                    (id, usuario_id, tipo, origem, nome, quantidade, preco_medio_brl, valor_atual_brl, moeda, dados_json)
-                  VALUES (?, ?, ?, 'importacao', ?, ?, ?, ?, 'BRL', ?)`,
-            valores: [gerarId(), usuarioId, item.tipo, item.nome, item.quantidade, item.precoMedioBrl, item.valorAtualBrl, item.dadosJson],
+                    (id, usuario_id, ativo_id, tipo, origem, nome, quantidade, preco_medio_brl, valor_atual_brl, moeda, dados_json)
+                  VALUES (?, ?, ?, ?, 'importacao', ?, ?, ?, ?, 'BRL', ?)`,
+            valores: [gerarId(), usuarioId, ativoId, item.tipo, item.nome, item.quantidade, item.precoMedioBrl, item.valorAtualBrl, item.dadosJson],
           });
-          operacoes.push({ sql: `UPDATE importacao_itens SET resultado = 'aceito' WHERE id = ?`, valores: [linha.id] });
+          operacoes.push({ sql: `UPDATE importacao_itens SET resultado = 'aceito' WHERE id = ?`, valores: [linhaId] });
         }
         await bd.emLote(operacoes);
         await repo.concluirImportacao(id, usuarioId);

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -109,6 +109,29 @@ test('confirma um lote criando a posição canônica uma única vez', async () =
   assert.match(lotes[0][1].sql, /resultado = 'aceito'/);
 });
 
+test('confirma fundo importado vinculando seu CNPJ ao catálogo canônico', async () => {
+  const lotes: { sql: string; valores: unknown[] }[][] = [];
+  const importacao = { id: 'importacao-2', usuario_id: 'usuario-1', origem: 'fundos.xlsx', status: 'pendente', iniciado_em: '2026-07-26', concluido_em: null };
+  const bd = {
+    consultar: async (sql: string) => sql.includes('ORDER BY linha')
+      ? [{ id: 'linha-fundo', linha: 1, tipo: 'desconhecido', resultado: 'pendente', dados_json: JSON.stringify({
+        aba: 'fundos', nome: 'Fundo CVM', cnpj: '12.345.678/0001-90', valorAplicado: 500,
+      }) }]
+      : [],
+    primeiro: async (sql: string) => sql.includes('FROM ativos') ? null : importacao,
+    executar: async () => ({ sucesso: true, linhasAfetadas: 1 }),
+    emLote: async (operacoes: { sql: string; valores: unknown[] }[]) => { lotes.push(operacoes); },
+  };
+
+  const resultado = await servicoPatrimonio(bd).confirmarImportacao('usuario-1', 'importacao-2');
+
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  assert.match(lotes[0][0].sql, /INSERT INTO ativos/);
+  assert.equal(lotes[0][0].valores[1], '12345678000190');
+  assert.match(lotes[0][1].sql, /INSERT INTO patrimonio_itens/);
+  assert.equal(lotes[0][1].valores[2], lotes[0][0].valores[0]);
+});
+
 test('expõe valor calculado e frescor da cotação no contrato patrimonial', async () => {
   const bd = {
     consultar: async () => [{


### PR DESCRIPTION
## O que mudou
- normaliza o CNPJ de fundos e previdência importados;
- cria ou reutiliza o ativo canônico antes da posição;
- vincula a posição ao catálogo, permitindo que o job CVM identifique o CNPJ ativo.

## Validação
- npm.cmd run typecheck
- npm.cmd run test:api (10 testes)
- npm.cmd run build