### PR TITLE
Sinaliza confiança dos snapshots mensais

### DIFF
--- a/apresentacao/src/features/historico/Historico.jsx
+++ b/apresentacao/src/features/historico/Historico.jsx
@@ -67,6 +67,7 @@ export default function Historico() {
             dataRef: anoMesParaData(p.anoMes),
             valorTotal: Number(p.patrimonioBrutoBrl ?? 0),
             variacaoPercentual: Number(p.rentabilidadeMesPct ?? 0),
+            ehConfiavel: p.ehConfiavel !== false,
           }))
           .filter((item) => {
             if (!item.dataRef) return false;
@@ -154,6 +155,7 @@ export default function Historico() {
                       <p className="text-[10px] text-[var(--text-secondary)] font-bold uppercase tracking-tight">
                         Variação {ocultarValores ? '••••••••' : `${snap.variacaoPercentual >= 0 ? '+' : ''}${snap.variacaoPercentual.toFixed(2)}%`}
                       </p>
+                      {!snap.ehConfiavel && <p className="text-[10px] text-[#9A6A16] font-bold uppercase tracking-tight">Dados incompletos ou desatualizados</p>}
                     </div>
                     <p className="font-['Sora'] text-sm font-bold">{ocultarValores ? '••••••••' : moeda(snap.valorTotal)}</p>
                   </div>

--- a/apresentacao/src/features/historico/HistoricoMobile.jsx
+++ b/apresentacao/src/features/historico/HistoricoMobile.jsx
@@ -70,6 +70,7 @@ export default function HistoricoMobile() {
             dataRef: anoMesParaData(p.anoMes),
             valorTotal: Number(p.patrimonioBrutoBrl ?? 0),
             variacaoPercentual: Number(p.rentabilidadeMesPct ?? 0),
+            ehConfiavel: p.ehConfiavel !== false,
           }))
           .filter((item) => {
             if (!item.dataRef) return false;
@@ -196,6 +197,7 @@ export default function HistoricoMobile() {
                           ? 'Variação ••••'
                           : `Variação ${Number(snap.variacaoPercentual ?? 0) >= 0 ? '+' : ''}${Number(snap.variacaoPercentual ?? 0).toFixed(2)}%`}
                       </p>
+                      {!snap.ehConfiavel && <p className="text-[10px] font-semibold uppercase text-[#9A6A16]">Dados incompletos ou desatualizados</p>}
                     </div>
                     <p className="font-['Sora'] text-[12px] font-bold text-[var(--text-primary)]">
                       {ocultarValores ? '••••••' : moeda(snap.valorTotal)}

--- a/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
+++ b/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
@@ -17,6 +17,12 @@ interface LinhaResumo {
   aporte_mes_brl: number | null;
 }
 
+interface LinhaConfianca {
+  total_itens: number;
+  itens_sem_valor: number;
+  itens_cotacao_expirada: number;
+}
+
 export async function historicoMensalJob(env: Env): Promise<void> {
   const bd = criarBd(env);
   const usuarios = await bd.consultar<LinhaUsuario>(`SELECT id FROM usuarios`);
@@ -33,18 +39,42 @@ export async function historicoMensalJob(env: Env): Promise<void> {
     );
     if (!resumo) continue;
 
+    const confianca = await bd.primeiro<LinhaConfianca>(
+      `SELECT
+          COUNT(*) AS total_itens,
+          SUM(CASE WHEN i.valor_atual_brl IS NULL THEN 1 ELSE 0 END) AS itens_sem_valor,
+          SUM(CASE WHEN i.quantidade IS NOT NULL AND i.ativo_id IS NOT NULL
+                    AND NOT EXISTS (
+                      SELECT 1 FROM ativos_cotacoes_cache c
+                       WHERE c.ativo_id = i.ativo_id AND c.expira_em >= ?
+                    )
+                   THEN 1 ELSE 0 END) AS itens_cotacao_expirada
+         FROM patrimonio_itens i WHERE i.usuario_id = ? AND i.esta_ativo = 1`,
+      timestamp, u.id,
+    );
+    const itensSemValor = confianca?.itens_sem_valor ?? 0;
+    const itensCotacaoExpirada = confianca?.itens_cotacao_expirada ?? 0;
+    const ehConfiavel = itensSemValor === 0 && itensCotacaoExpirada === 0 ? 1 : 0;
+    const dadosJson = JSON.stringify({
+      totalItens: confianca?.total_itens ?? 0,
+      itensSemValor,
+      itensCotacaoExpirada,
+    });
+
     await bd.executar(
       `INSERT INTO patrimonio_historico_mensal (
           usuario_id, ano_mes,
           patrimonio_bruto_brl, patrimonio_liquido_brl, divida_brl,
           aporte_mes_brl, rentabilidade_mes_pct, eh_confiavel,
           dados_json, atualizado_em
-        ) VALUES (?, ?, ?, ?, ?, ?, NULL, 1, '{}', ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
        ON CONFLICT(usuario_id, ano_mes) DO UPDATE SET
          patrimonio_bruto_brl = excluded.patrimonio_bruto_brl,
          patrimonio_liquido_brl = excluded.patrimonio_liquido_brl,
          divida_brl = excluded.divida_brl,
          aporte_mes_brl = excluded.aporte_mes_brl,
+         eh_confiavel = excluded.eh_confiavel,
+         dados_json = excluded.dados_json,
          atualizado_em = excluded.atualizado_em`,
       u.id,
       anoMes,
@@ -52,6 +82,8 @@ export async function historicoMensalJob(env: Env): Promise<void> {
       resumo.patrimonio_liquido_brl ?? 0,
       resumo.divida_brl ?? 0,
       resumo.aporte_mes_brl ?? 0,
+      ehConfiavel,
+      dadosJson,
       timestamp,
     );
   }

--- a/servidores/porta-entrada/testes/historico-mensal.job.test.ts
+++ b/servidores/porta-entrada/testes/historico-mensal.job.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Env } from '../src/infra/bd';
+import { historicoMensalJob } from '../src/jobs/historico-mensal.job';
+
+test('snapshot mensal reduz a confiança quando há cotação expirada', async () => {
+  const execucoes: { sql: string; valores: unknown[] }[] = [];
+  const bd = {
+    prepare(sql: string) {
+      return {
+        bind(...valores: unknown[]) {
+          return {
+            all: async () => ({ results: [{ id: 'usuario-1' }] }),
+            first: async () => sql.includes('vw_patrimonio_resumo')
+              ? { patrimonio_bruto_brl: 100, patrimonio_liquido_brl: 100, divida_brl: 0, aporte_mes_brl: 0 }
+              : { total_itens: 2, itens_sem_valor: 0, itens_cotacao_expirada: 1 },
+            run: async () => {
+              execucoes.push({ sql, valores });
+              return { success: true, meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+    batch: async () => [],
+  };
+
+  await historicoMensalJob({ DB: bd } as unknown as Env);
+
+  assert.equal(execucoes.length, 1);
+  assert.match(execucoes[0].sql, /ON CONFLICT\(usuario_id, ano_mes\)/);
+  assert.equal(execucoes[0].valores[6], 0);
+  assert.deepEqual(JSON.parse(execucoes[0].valores[7] as string), {
+    totalItens: 2, itensSemValor: 0, itensCotacaoExpirada: 1,
+  });
+});


### PR DESCRIPTION
## O que mudou
- o job mensal mede posições sem valor e cotações expiradas;
- grava eh_confiavel e o diagnóstico do snapshot de forma idempotente;
- Histórico desktop e mobile informam quando o ponto está incompleto ou desatualizado.

## Por quê
O histórico não deve apresentar precisão indevida quando o mercado não forneceu uma cotação utilizável.

## Validação
- npm.cmd run typecheck
- npm.cmd run test:api (11 testes)
- npm.cmd run build