### PR TITLE
Enfileira reconstrução após importação

### DIFF
--- a/infra/banco/migrations/102_fila_reconstrucao_idempotente.sql
+++ b/infra/banco/migrations/102_fila_reconstrucao_idempotente.sql
@@ -1,0 +1,3 @@
+-- Uma única reconstrução pendente por usuário. O reenvio atualiza a mesma fila.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_patrimonio_fila_reconstrucao_usuario
+  ON patrimonio_fila_reconstrucao(usuario_id);

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -434,6 +434,20 @@ export const servicoPatrimonio = (bd: Bd) => {
           });
           operacoes.push({ sql: `UPDATE importacao_itens SET resultado = 'aceito' WHERE id = ?`, valores: [linhaId] });
         }
+        if (aceitos > 0) {
+          operacoes.push({
+            sql: `INSERT INTO patrimonio_fila_reconstrucao (id, usuario_id, motivo, status)
+                  VALUES (?, ?, 'importacao_confirmada', 'pendente')
+                  ON CONFLICT(usuario_id) DO UPDATE SET
+                    motivo = excluded.motivo,
+                    status = 'pendente',
+                    agendado_em = datetime('now'),
+                    iniciado_em = NULL,
+                    processado_em = NULL,
+                    erro = NULL`,
+            valores: [gerarId(), usuarioId],
+          });
+        }
         await bd.emLote(operacoes);
         await repo.concluirImportacao(id, usuarioId);
         const confirmada = await this.obterImportacao(usuarioId, id);

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -107,6 +107,7 @@ test('confirma um lote criando a posição canônica uma única vez', async () =
   assert.equal(resultado.dados.itensRejeitados, 0);
   assert.match(lotes[0][0].sql, /INSERT INTO patrimonio_itens/);
   assert.match(lotes[0][1].sql, /resultado = 'aceito'/);
+  assert.match(lotes[0][2].sql, /INSERT INTO patrimonio_fila_reconstrucao/);
 });
 
 test('confirma fundo importado vinculando seu CNPJ ao catálogo canônico', async () => {


### PR DESCRIPTION
## O que mudou
- a confirmação de importação enfileira a reconstrução no mesmo batch das posições;
- a fila passa a ter um único registro por usuário;
- reenvios reativam a mesma fila, sem acumular duplicatas.

## Operação D1
A migration 102, apenas um índice único sobre uma fila vazia, já foi aplicada e verificada no banco remoto.

## Validação
- npm.cmd run typecheck
- npm.cmd run test:api (11 testes)
- npm.cmd run build