### PR TITLE
Preserva valores manuais na reconstrução

### DIFF
--- a/servidores/porta-entrada/src/jobs/patrimonio-reconstruir.job.ts
+++ b/servidores/porta-entrada/src/jobs/patrimonio-reconstruir.job.ts
@@ -39,13 +39,14 @@ export async function patrimonioReconstruirJob(env: Env): Promise<void> {
         `SELECT p.id, p.quantidade, p.preco_medio_brl,
                 (SELECT preco_brl FROM ativos_cotacoes_cache c WHERE c.ativo_id = p.ativo_id ORDER BY cotado_em DESC LIMIT 1) AS preco_atual_brl
            FROM patrimonio_itens p
-          WHERE p.usuario_id = ? AND p.esta_ativo = 1`,
+          WHERE p.usuario_id = ? AND p.esta_ativo = 1 AND p.quantidade IS NOT NULL`,
         tarefa.usuario_id,
       );
 
       for (const item of itens) {
-        const preco = item.preco_atual_brl ?? item.preco_medio_brl ?? 0;
-        const quantidade = item.quantidade ?? 0;
+        const preco = item.preco_atual_brl ?? item.preco_medio_brl;
+        const quantidade = item.quantidade;
+        if (preco === null || quantidade === null) continue;
         const valor = quantidade * preco;
         await bd.executar(
           `UPDATE patrimonio_itens SET valor_atual_brl = ?, atualizado_em = ? WHERE id = ?`,

--- a/servidores/porta-entrada/testes/patrimonio-reconstruir.job.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-reconstruir.job.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Env } from '../src/infra/bd';
+import { patrimonioReconstruirJob } from '../src/jobs/patrimonio-reconstruir.job';
+
+test('reconstrução atualiza somente posições com quantidade e preserva valores manuais', async () => {
+  const consultas: string[] = [];
+  const execucoes: { sql: string; valores: unknown[] }[] = [];
+  const bd = {
+    prepare(sql: string) {
+      return {
+        bind(...valores: unknown[]) {
+          return {
+            all: async () => {
+              consultas.push(sql);
+              if (sql.includes('FROM patrimonio_fila_reconstrucao')) return { results: [{ id: 'fila-1', usuario_id: 'usuario-1' }] };
+              return { results: [{ id: 'acao-1', quantidade: 10, preco_medio_brl: 5, preco_atual_brl: null }] };
+            },
+            first: async () => null,
+            run: async () => {
+              execucoes.push({ sql, valores });
+              return { success: true, meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+    batch: async () => [],
+  };
+
+  await patrimonioReconstruirJob({ DB: bd } as unknown as Env);
+
+  assert.match(consultas[1], /p\.quantidade IS NOT NULL/);
+  const atualizacao = execucoes.find((execucao) => execucao.sql.includes('UPDATE patrimonio_itens'));
+  assert.ok(atualizacao);
+  assert.equal(atualizacao.valores[0], 50);
+});


### PR DESCRIPTION
## O que mudou
- a reconstrução só recalcula posições com quantidade;
- posições manuais sem quantidade mantêm seu valor confirmado;
- quando não há preço nem preço médio, o job não substitui o valor por zero.

## Por quê
A fila passou a ser criada após a importação; sem esta proteção, um item manual poderia ser zerado durante a reconstrução.

## Validação
- npm.cmd run typecheck
- npm.cmd run test:api (12 testes)
- npm.cmd run build