### PR TITLE
Expõe movimentos patrimoniais

### DIFF
--- a/bibliotecas/contratos/patrimonio.ts
+++ b/bibliotecas/contratos/patrimonio.ts
@@ -8,6 +8,7 @@ export type OrigemItemPatrimonio = 'manual' | 'importacao' | 'vinculo_corretora'
 export type EstadoValorPatrimonial = 'cotacao' | 'manual' | 'indisponivel';
 
 export type TipoAporte = 'aporte' | 'retirada' | 'transferencia' | 'ajuste';
+export type TipoMovimentoPatrimonial = 'compra' | 'venda' | 'aporte' | 'retirada' | 'transferencia' | 'resgate' | 'ajuste' | 'correcao';
 
 export interface ItemPatrimonioSaida {
   id: string;
@@ -78,6 +79,21 @@ export interface AporteCriarEntrada {
   valorBrl: number;
   data: string;
   descricao?: string | null;
+}
+
+export interface MovimentoPatrimonialSaida {
+  id: string;
+  usuarioId: string;
+  itemId: string;
+  importacaoId: string | null;
+  linhaImportacao: number | null;
+  tipo: TipoMovimentoPatrimonial;
+  quantidade: number | null;
+  valorBrl: number | null;
+  data: string;
+  origem: OrigemItemPatrimonio;
+  dadosJson: Record<string, unknown>;
+  criadoEm: string;
 }
 
 export interface HistoricoMensalItem {

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -125,6 +125,21 @@ export interface LinhaItemImportacao {
   dados_json: string;
 }
 
+export interface LinhaMovimentoPatrimonial {
+  id: string;
+  usuario_id: string;
+  item_id: string;
+  importacao_id: string | null;
+  linha_importacao: number | null;
+  tipo: string;
+  quantidade: number | null;
+  valor_brl: number | null;
+  data: string;
+  origem: string;
+  dados_json: string;
+  criado_em: string;
+}
+
 export const repositorioPatrimonio = (bd: Bd) => ({
   async buscarAtivoPorCnpj(cnpj: string) {
     return bd.primeiro<{ id: string }>(`SELECT id FROM ativos WHERE cnpj = ? LIMIT 1`, cnpj);
@@ -210,6 +225,17 @@ export const repositorioPatrimonio = (bd: Bd) => ({
     return bd.primeiro<LinhaItemPatrimonio>(
       `SELECT * FROM patrimonio_itens WHERE usuario_id = ? AND id = ? LIMIT 1`,
       usuarioId, id,
+    );
+  },
+
+  async listarMovimentosItem(usuarioId: string, itemId: string, limite = 200): Promise<LinhaMovimentoPatrimonial[]> {
+    return bd.consultar<LinhaMovimentoPatrimonial>(
+      `SELECT id, usuario_id, item_id, importacao_id, linha_importacao, tipo, quantidade,
+              valor_brl, data, origem, dados_json, criado_em
+         FROM patrimonio_movimentos
+        WHERE usuario_id = ? AND item_id = ?
+        ORDER BY data DESC, criado_em DESC LIMIT ?`,
+      usuarioId, itemId, limite,
     );
   },
 

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.rotas.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.rotas.ts
@@ -20,6 +20,9 @@ export async function rotearPatrimonio(
     return servico.criarItem(sessao.usuarioId, await lerJson(request) as never);
   }
 
+  const mMovimentosItem = caminho.match(/^\/api\/patrimonio\/itens\/([^/]+)\/movimentos$/);
+  if (mMovimentosItem && metodo === 'GET') return servico.listarMovimentosItem(sessao.usuarioId, mMovimentosItem[1]);
+
   const mItem = caminho.match(/^\/api\/patrimonio\/itens\/([^/]+)$/);
   if (mItem) {
     const id = mItem[1];

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -6,6 +6,7 @@ import type {
   PatrimonioScoreSaida, ScoreFaixa, ScorePilar,
   TipoItemPatrimonio, OrigemItemPatrimonio,
   ImportacaoSaida, ImportacaoCriarEntrada, ImportacaoConfirmarSaida,
+  MovimentoPatrimonialSaida, TipoMovimentoPatrimonial,
 } from '@ei/contratos';
 import type { Bd } from '../../infra/bd';
 import { gerarId } from '../../infra/bd';
@@ -14,6 +15,7 @@ import { calcularAlocacao } from './calculos/alocacao';
 import {
   repositorioPatrimonio, type LinhaAlocacao, type LinhaAporte,
   type LinhaEvolucao, type LinhaPosicao, type LinhaResumo, type LinhaScoreAtual,
+  type LinhaMovimentoPatrimonial,
 } from './patrimonio.repositorio';
 
 const paraItemSaida = (l: LinhaPosicao, totalBrl: number): ItemPatrimonioSaida => {
@@ -59,6 +61,21 @@ const paraAporteSaida = (l: LinhaAporte): AporteSaida => ({
   data: l.data,
   descricao: l.descricao,
   origem: l.origem,
+  criadoEm: l.criado_em,
+});
+
+const paraMovimentoSaida = (l: LinhaMovimentoPatrimonial): MovimentoPatrimonialSaida => ({
+  id: l.id,
+  usuarioId: l.usuario_id,
+  itemId: l.item_id,
+  importacaoId: l.importacao_id,
+  linhaImportacao: l.linha_importacao,
+  tipo: l.tipo as TipoMovimentoPatrimonial,
+  quantidade: l.quantidade,
+  valorBrl: l.valor_brl,
+  data: l.data,
+  origem: l.origem as OrigemItemPatrimonio,
+  dadosJson: JSON.parse(l.dados_json) as Record<string, unknown>,
   criadoEm: l.criado_em,
 });
 
@@ -228,6 +245,13 @@ export const servicoPatrimonio = (bd: Bd) => {
       const alvo = posicoes.find((p) => p.item_id === id);
       if (!alvo) return erro('item_nao_encontrado', 'Item de patrimônio não encontrado', 404);
       return sucesso(paraItemSaida(alvo, total));
+    },
+
+    async listarMovimentosItem(usuarioId: string, itemId: string): Promise<ServiceResponse<{ itens: MovimentoPatrimonialSaida[] }>> {
+      const item = await repo.buscarItemBruto(usuarioId, itemId);
+      if (!item) return erro('item_nao_encontrado', 'Item de patrimônio não encontrado', 404);
+      const movimentos = await repo.listarMovimentosItem(usuarioId, itemId);
+      return sucesso({ itens: movimentos.map(paraMovimentoSaida) });
     },
 
     async criarItem(usuarioId: string, e: ItemPatrimonioCriarEntrada): Promise<ServiceResponse<ItemPatrimonioSaida>> {

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -158,3 +158,24 @@ test('expõe valor calculado e frescor da cotação no contrato patrimonial', as
   assert.equal(resultado.dados.itens[0].fonteCotacao, 'cvm');
   assert.equal(resultado.dados.itens[0].cotacaoReferenciaEm, '2026-07-24');
 });
+
+test('lista somente os movimentos do item do usuário autenticado', async () => {
+  const bd = {
+    consultar: async (sql: string) => sql.includes('FROM patrimonio_movimentos') ? [{
+      id: 'movimento-1', usuario_id: 'usuario-1', item_id: 'item-1', importacao_id: 'importacao-1', linha_importacao: 3,
+      tipo: 'compra', quantidade: 10, valor_brl: 300, data: '2026-07-20', origem: 'importacao',
+      dados_json: '{"aba":"acoes"}', criado_em: '2026-07-20T10:00:00.000Z',
+    }] : [],
+    primeiro: async (sql: string) => sql.includes('FROM patrimonio_itens') ? { id: 'item-1' } : null,
+    executar: async () => ({ sucesso: true, linhasAfetadas: 0 }),
+    emLote: async () => {},
+  };
+  const resultado = await servicoPatrimonio(bd).listarMovimentosItem('usuario-1', 'item-1');
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  if (!resultado.ok) return;
+  assert.deepEqual(resultado.dados.itens[0], {
+    id: 'movimento-1', usuarioId: 'usuario-1', itemId: 'item-1', importacaoId: 'importacao-1', linhaImportacao: 3,
+    tipo: 'compra', quantidade: 10, valorBrl: 300, data: '2026-07-20', origem: 'importacao',
+    dadosJson: { aba: 'acoes' }, criadoEm: '2026-07-20T10:00:00.000Z',
+  });
+});


### PR DESCRIPTION
## Alterações

- adiciona contrato de movimentos patrimoniais;
- expõe GET /api/patrimonio/itens/:id/movimentos;
- retorna os movimentos em ordem de data, sempre filtrados pelo item e usuário autenticado.

## Impacto

A importação já grava seus movimentos canônicos. Esta API torna a trilha consultável para a futura tela de detalhes e para auditoria, sem alterar posições nem acionar reconstruções.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (13 testes)