### PR TITLE
Registra movimentos manuais

### DIFF
--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -252,6 +252,28 @@ export const repositorioPatrimonio = (bd: Bd) => ({
     );
   },
 
+  async inserirItemComMovimento(
+    id: string, usuarioId: string, ativoId: string | null, tipo: string, origem: string,
+    nome: string, quantidade: number | null, precoMedioBrl: number | null, valorAtualBrl: number | null,
+    moeda: string, dadosJson: string,
+    movimentoId: string, tipoMovimento: string, dataMovimento: string,
+  ): Promise<void> {
+    await bd.emLote([
+      {
+        sql: `INSERT INTO patrimonio_itens
+                (id, usuario_id, ativo_id, tipo, origem, nome, quantidade, preco_medio_brl, valor_atual_brl, moeda, dados_json)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        valores: [id, usuarioId, ativoId, tipo, origem, nome, quantidade, precoMedioBrl, valorAtualBrl, moeda, dadosJson],
+      },
+      {
+        sql: `INSERT INTO patrimonio_movimentos
+                (id, usuario_id, item_id, tipo, quantidade, valor_brl, data, origem, dados_json)
+              VALUES (?, ?, ?, ?, ?, ?, ?, 'manual', ?)`,
+        valores: [movimentoId, usuarioId, id, tipoMovimento, quantidade, valorAtualBrl, dataMovimento, dadosJson],
+      },
+    ]);
+  },
+
   async atualizarItem(
     id: string, usuarioId: string,
     campos: {

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -108,6 +108,12 @@ const normalizarCnpjPatrimonial = (valor: string): string | null => {
 
 const aceitaCnpj = (tipo: TipoItemPatrimonio): boolean => tipo === 'fundo' || tipo === 'previdencia';
 
+const tipoMovimentoInicial = (tipo: TipoItemPatrimonio): TipoMovimentoPatrimonial => {
+  if (tipo === 'acao' || tipo === 'fii' || tipo === 'etf' || tipo === 'cripto') return 'compra';
+  if (tipo === 'fundo' || tipo === 'previdencia' || tipo === 'renda_fixa' || tipo === 'poupanca' || tipo === 'caixa') return 'aporte';
+  return 'ajuste';
+};
+
 const serializarEstavel = (valor: unknown): string => {
   if (Array.isArray(valor)) return `[${valor.map(serializarEstavel).join(',')}]`;
   if (valor && typeof valor === 'object') {
@@ -271,10 +277,12 @@ export const servicoPatrimonio = (bd: Bd) => {
         }
       }
       const id = gerarId();
-      await repo.inserirItem(
+      const dadosJson = JSON.stringify(e.dadosJson ?? {});
+      await repo.inserirItemComMovimento(
         id, usuarioId, ativoId, e.tipo, 'manual', e.nome,
         e.quantidade ?? null, e.precoMedioBrl ?? null, e.valorAtualBrl ?? null,
-        e.moeda ?? 'BRL', JSON.stringify(e.dadosJson ?? {}),
+        e.moeda ?? 'BRL', dadosJson,
+        gerarId(), tipoMovimentoInicial(e.tipo), new Date().toISOString().slice(0, 10),
       );
       return this.obterItem(usuarioId, id);
     },

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -4,10 +4,11 @@ import { servicoPatrimonio } from '../src/dominios/patrimonio/patrimonio.servico
 
 test('vincula um fundo manual ao ativo canônico pelo CNPJ', async () => {
   const execucoes: { sql: string; valores: unknown[] }[] = [];
+  const lotes: { sql: string; valores: unknown[] }[][] = [];
   let buscasAtivo = 0;
   const bd = {
     consultar: async () => [{
-      item_id: execucoes.at(-1)?.valores[0], usuario_id: 'usuario-1', tipo: 'fundo', origem: 'manual', nome: 'Fundo teste',
+      item_id: lotes[0]?.[0].valores[0], usuario_id: 'usuario-1', tipo: 'fundo', origem: 'manual', nome: 'Fundo teste',
       ativo_id: 'ativo-1', ticker: null, cnpj: '12345678000190', classe: null, subclasse: null,
       quantidade: 1, preco_medio_brl: 10, valor_atual_brl: 10, preco_atual_brl: 10,
       preco_atualizado_em: null, preco_fonte: null, rentabilidade_pct: null,
@@ -21,7 +22,7 @@ test('vincula um fundo manual ao ativo canônico pelo CNPJ', async () => {
       execucoes.push({ sql, valores });
       return { sucesso: true, linhasAfetadas: 1 };
     },
-    emLote: async () => {},
+    emLote: async (operacoes: { sql: string; valores: unknown[] }[]) => { lotes.push(operacoes); },
   };
 
   const resultado = await servicoPatrimonio(bd).criarItem('usuario-1', {
@@ -31,8 +32,34 @@ test('vincula um fundo manual ao ativo canônico pelo CNPJ', async () => {
   assert.equal(resultado.ok, true, JSON.stringify(resultado));
   assert.match(execucoes[0].sql, /INSERT INTO ativos/);
   assert.equal(execucoes[0].valores[1], '12345678000190');
-  assert.match(execucoes[1].sql, /INSERT INTO patrimonio_itens/);
-  assert.equal(execucoes[1].valores[2], execucoes[0].valores[0]);
+  assert.match(lotes[0][0].sql, /INSERT INTO patrimonio_itens/);
+  assert.equal(lotes[0][0].valores[2], execucoes[0].valores[0]);
+  assert.match(lotes[0][1].sql, /INSERT INTO patrimonio_movimentos/);
+  assert.equal(lotes[0][1].valores[3], 'aporte');
+});
+
+test('cadastro manual de ação cria movimento de compra na mesma operação', async () => {
+  const lotes: { sql: string; valores: unknown[] }[][] = [];
+  const bd = {
+    consultar: async () => [{
+      item_id: lotes[0]?.[0].valores[0] ?? 'item-1', usuario_id: 'usuario-1', tipo: 'acao', origem: 'manual', nome: 'Ação teste',
+      ativo_id: null, ticker: null, cnpj: null, classe: null, subclasse: null, quantidade: 2,
+      preco_medio_brl: 10, valor_atual_brl: 20, preco_atual_brl: null, preco_atualizado_em: null,
+      preco_fonte: null, rentabilidade_pct: null, criado_em: '2026-07-26', atualizado_em: '2026-07-26',
+    }],
+    primeiro: async () => null,
+    executar: async () => ({ sucesso: true, linhasAfetadas: 1 }),
+    emLote: async (operacoes: { sql: string; valores: unknown[] }[]) => { lotes.push(operacoes); },
+  };
+  const resultado = await servicoPatrimonio(bd).criarItem('usuario-1', {
+    tipo: 'acao', nome: 'Ação teste', quantidade: 2, precoMedioBrl: 10, valorAtualBrl: 20,
+  });
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  assert.match(lotes[0][0].sql, /INSERT INTO patrimonio_itens/);
+  assert.match(lotes[0][1].sql, /INSERT INTO patrimonio_movimentos/);
+  assert.equal(lotes[0][1].valores[3], 'compra');
+  assert.equal(lotes[0][1].valores[4], 2);
+  assert.equal(lotes[0][1].valores[5], 20);
 });
 
 test('rejeita CNPJ fora de fundo ou previdência', async () => {


### PR DESCRIPTION
## Alterações

- cria a posição manual e seu movimento inicial na mesma operação D1;
- classifica ativos negociáveis como compra, posições financeiras como aporte e bens como ajuste;
- preserva o vínculo por CNPJ para fundos e previdência.

## Impacto

Agora a trilha de movimentos cobre tanto importações quanto novos cadastros manuais, evitando posições sem evento de origem.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (14 testes)