### PR TITLE
Registra correções manuais

### DIFF
--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -304,6 +304,44 @@ export const repositorioPatrimonio = (bd: Bd) => ({
     );
   },
 
+  async atualizarItemComMovimento(
+    id: string, usuarioId: string,
+    campos: {
+      ativoId?: string | null;
+      tipo?: string; nome?: string; quantidade?: number | null;
+      precoMedioBrl?: number | null; valorAtualBrl?: number | null;
+      moeda?: string; estaAtivo?: boolean; dadosJson?: string;
+    },
+    movimento: { id: string; quantidade: number | null; valorBrl: number | null; data: string; dadosJson: string },
+  ): Promise<void> {
+    const partes: string[] = [];
+    const vals: unknown[] = [];
+    const set = (col: string, v: unknown) => { partes.push(`${col} = ?`); vals.push(v); };
+    if (campos.ativoId !== undefined) set('ativo_id', campos.ativoId);
+    if (campos.tipo !== undefined) set('tipo', campos.tipo);
+    if (campos.nome !== undefined) set('nome', campos.nome);
+    if (campos.quantidade !== undefined) set('quantidade', campos.quantidade);
+    if (campos.precoMedioBrl !== undefined) set('preco_medio_brl', campos.precoMedioBrl);
+    if (campos.valorAtualBrl !== undefined) set('valor_atual_brl', campos.valorAtualBrl);
+    if (campos.moeda !== undefined) set('moeda', campos.moeda);
+    if (campos.estaAtivo !== undefined) set('esta_ativo', campos.estaAtivo ? 1 : 0);
+    if (campos.dadosJson !== undefined) set('dados_json', campos.dadosJson);
+    partes.push("atualizado_em = datetime('now')");
+    vals.push(id, usuarioId);
+    await bd.emLote([
+      {
+        sql: `UPDATE patrimonio_itens SET ${partes.join(', ')} WHERE id = ? AND usuario_id = ?`,
+        valores: vals,
+      },
+      {
+        sql: `INSERT INTO patrimonio_movimentos
+                (id, usuario_id, item_id, tipo, quantidade, valor_brl, data, origem, dados_json)
+              VALUES (?, ?, ?, 'correcao', ?, ?, ?, 'manual', ?)`,
+        valores: [movimento.id, usuarioId, id, movimento.quantidade, movimento.valorBrl, movimento.data, movimento.dadosJson],
+      },
+    ]);
+  },
+
   async removerItem(id: string, usuarioId: string): Promise<void> {
     await bd.executar(`DELETE FROM patrimonio_itens WHERE id = ? AND usuario_id = ?`, id, usuarioId);
   },

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -308,11 +308,26 @@ export const servicoPatrimonio = (bd: Bd) => {
           }
         }
       }
-      await repo.atualizarItem(id, usuarioId, {
+      const campos = {
         ...e,
         ativoId,
         dadosJson: e.dadosJson !== undefined ? JSON.stringify(e.dadosJson) : undefined,
-      });
+      };
+      const alteraValor = e.quantidade !== undefined || e.precoMedioBrl !== undefined || e.valorAtualBrl !== undefined;
+      if (alteraValor) {
+        const quantidade = e.quantidade !== undefined ? e.quantidade : atual.quantidade;
+        const valorBrl = e.valorAtualBrl !== undefined ? e.valorAtualBrl : atual.valor_atual_brl;
+        await repo.atualizarItemComMovimento(id, usuarioId, campos, {
+          id: gerarId(), quantidade, valorBrl, data: new Date().toISOString().slice(0, 10),
+          dadosJson: JSON.stringify({
+            tipo: 'correcao_manual',
+            anterior: { quantidade: atual.quantidade, precoMedioBrl: atual.preco_medio_brl, valorAtualBrl: atual.valor_atual_brl },
+            novo: { quantidade, precoMedioBrl: e.precoMedioBrl !== undefined ? e.precoMedioBrl : atual.preco_medio_brl, valorAtualBrl: valorBrl },
+          }),
+        });
+      } else {
+        await repo.atualizarItem(id, usuarioId, campos);
+      }
       return this.obterItem(usuarioId, id);
     },
 

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -62,6 +62,32 @@ test('cadastro manual de ação cria movimento de compra na mesma operação', a
   assert.equal(lotes[0][1].valores[5], 20);
 });
 
+test('correção manual de valor cria movimento atômico com estado anterior e novo', async () => {
+  const lotes: { sql: string; valores: unknown[] }[][] = [];
+  const bd = {
+    consultar: async () => [{
+      item_id: 'item-1', usuario_id: 'usuario-1', tipo: 'acao', origem: 'manual', nome: 'Ação teste', ativo_id: null,
+      ticker: null, cnpj: null, classe: null, subclasse: null, quantidade: 2, preco_medio_brl: 10,
+      valor_atual_brl: 25, preco_atual_brl: null, preco_atualizado_em: null, preco_fonte: null,
+      rentabilidade_pct: null, criado_em: '2026-07-26', atualizado_em: '2026-07-26',
+    }],
+    primeiro: async () => ({ id: 'item-1', quantidade: 2, preco_medio_brl: 10, valor_atual_brl: 20, nome: 'Ação teste', tipo: 'acao' }),
+    executar: async () => ({ sucesso: true, linhasAfetadas: 1 }),
+    emLote: async (operacoes: { sql: string; valores: unknown[] }[]) => { lotes.push(operacoes); },
+  };
+  const resultado = await servicoPatrimonio(bd).atualizarItem('usuario-1', 'item-1', { valorAtualBrl: 25 });
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  assert.match(lotes[0][0].sql, /UPDATE patrimonio_itens/);
+  assert.match(lotes[0][1].sql, /INSERT INTO patrimonio_movimentos/);
+  assert.equal(lotes[0][1].valores[3], 2);
+  assert.equal(lotes[0][1].valores[4], 25);
+  assert.deepEqual(JSON.parse(lotes[0][1].valores[6] as string), {
+    tipo: 'correcao_manual',
+    anterior: { quantidade: 2, precoMedioBrl: 10, valorAtualBrl: 20 },
+    novo: { quantidade: 2, precoMedioBrl: 10, valorAtualBrl: 25 },
+  });
+});
+
 test('rejeita CNPJ fora de fundo ou previdência', async () => {
   const bd = { consultar: async () => [], primeiro: async () => null, executar: async () => ({ sucesso: true, linhasAfetadas: 0 }), emLote: async () => {} };
   const resultado = await servicoPatrimonio(bd).criarItem('usuario-1', {


### PR DESCRIPTION
## Alterações

- uma alteração manual de quantidade, preço médio ou valor passa a criar um movimento de correção;
- posição e correção são persistidas na mesma operação D1;
- o movimento preserva o estado anterior e o novo para auditoria.

## Impacto

A trilha patrimonial deixa de perder as alterações financeiras feitas depois do cadastro inicial.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (15 testes)