### PR TITLE
Preserva histórico na baixa de posições

### DIFF
--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.repositorio.ts
@@ -342,8 +342,24 @@ export const repositorioPatrimonio = (bd: Bd) => ({
     ]);
   },
 
-  async removerItem(id: string, usuarioId: string): Promise<void> {
-    await bd.executar(`DELETE FROM patrimonio_itens WHERE id = ? AND usuario_id = ?`, id, usuarioId);
+  async desativarItemComMovimento(
+    id: string, usuarioId: string,
+    movimento: { id: string; quantidade: number | null; valorBrl: number | null; data: string; dadosJson: string },
+  ): Promise<void> {
+    await bd.emLote([
+      {
+        sql: `UPDATE patrimonio_itens
+                SET esta_ativo = 0, atualizado_em = datetime('now')
+              WHERE id = ? AND usuario_id = ?`,
+        valores: [id, usuarioId],
+      },
+      {
+        sql: `INSERT INTO patrimonio_movimentos
+                (id, usuario_id, item_id, tipo, quantidade, valor_brl, data, origem, dados_json)
+              VALUES (?, ?, ?, 'retirada', ?, ?, ?, 'manual', ?)`,
+        valores: [movimento.id, usuarioId, id, movimento.quantidade, movimento.valorBrl, movimento.data, movimento.dadosJson],
+      },
+    ]);
   },
 
   async listarAportes(usuarioId: string, limite = 200): Promise<LinhaAporte[]> {

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -334,7 +334,15 @@ export const servicoPatrimonio = (bd: Bd) => {
     async removerItem(usuarioId: string, id: string): Promise<ServiceResponse<{ removido: true }>> {
       const atual = await repo.buscarItemBruto(usuarioId, id);
       if (!atual) return erro('item_nao_encontrado', 'Item de patrimônio não encontrado', 404);
-      await repo.removerItem(id, usuarioId);
+      await repo.desativarItemComMovimento(id, usuarioId, {
+        id: gerarId(), quantidade: atual.quantidade, valorBrl: atual.valor_atual_brl,
+        data: new Date().toISOString().slice(0, 10),
+        dadosJson: JSON.stringify({
+          tipo: 'baixa_manual',
+          quantidade: atual.quantidade,
+          valorAtualBrl: atual.valor_atual_brl,
+        }),
+      });
       return sucesso({ removido: true });
     },
 

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -88,6 +88,26 @@ test('correção manual de valor cria movimento atômico com estado anterior e n
   });
 });
 
+test('baixa de item preserva o histórico com retirada em vez de excluir a posição', async () => {
+  const lotes: { sql: string; valores: unknown[] }[][] = [];
+  const bd = {
+    consultar: async () => [],
+    primeiro: async () => ({ id: 'item-1', quantidade: 2, preco_medio_brl: 10, valor_atual_brl: 25, nome: 'Ação teste', tipo: 'acao' }),
+    executar: async () => ({ sucesso: true, linhasAfetadas: 1 }),
+    emLote: async (operacoes: { sql: string; valores: unknown[] }[]) => { lotes.push(operacoes); },
+  };
+  const resultado = await servicoPatrimonio(bd).removerItem('usuario-1', 'item-1');
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  assert.match(lotes[0][0].sql, /esta_ativo = 0/);
+  assert.doesNotMatch(lotes[0][0].sql, /DELETE FROM patrimonio_itens/);
+  assert.match(lotes[0][1].sql, /INSERT INTO patrimonio_movimentos/);
+  assert.equal(lotes[0][1].valores[3], 2);
+  assert.equal(lotes[0][1].valores[4], 25);
+  assert.deepEqual(JSON.parse(lotes[0][1].valores[6] as string), {
+    tipo: 'baixa_manual', quantidade: 2, valorAtualBrl: 25,
+  });
+});
+
 test('rejeita CNPJ fora de fundo ou previdência', async () => {
   const bd = { consultar: async () => [], primeiro: async () => null, executar: async () => ({ sucesso: true, linhasAfetadas: 0 }), emLote: async () => {} };
   const resultado = await servicoPatrimonio(bd).criarItem('usuario-1', {


### PR DESCRIPTION
## Alterações

- DELETE de posição passa a realizar baixa lógica;
- a baixa registra um movimento de retirada no mesmo lote D1;
- remove o caminho de exclusão física que apagava movimentos por cascata.

## Impacto

O histórico patrimonial permanece auditável mesmo quando o usuário remove uma posição da carteira ativa.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (16 testes)