### PR TITLE
Reconstrói histórico por movimentos

### DIFF
--- a/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
+++ b/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
@@ -5,6 +5,7 @@
 
 import type { Env } from '../infra/bd';
 import { agora, criarBd } from '../infra/bd';
+import { reconstruirHistoricoDeMovimentos, type MovimentoHistorico } from './patrimonio-historico.movimentos';
 
 interface LinhaUsuario {
   id: string;
@@ -23,6 +24,10 @@ interface LinhaConfianca {
   itens_cotacao_expirada: number;
 }
 
+interface LinhaContagemItens {
+  total_itens: number;
+}
+
 export async function historicoMensalJob(env: Env): Promise<void> {
   const bd = criarBd(env);
   const usuarios = await bd.consultar<LinhaUsuario>(`SELECT id FROM usuarios`);
@@ -32,6 +37,46 @@ export async function historicoMensalJob(env: Env): Promise<void> {
   const timestamp = agora();
 
   for (const u of usuarios) {
+    const [movimentos, itens] = await Promise.all([
+      bd.consultar<MovimentoHistorico>(
+        `SELECT m.item_id, i.tipo AS item_tipo, m.tipo, m.valor_brl, m.data, m.criado_em
+           FROM patrimonio_movimentos m
+           INNER JOIN patrimonio_itens i ON i.id = m.item_id
+          WHERE m.usuario_id = ?
+          ORDER BY m.data ASC, m.criado_em ASC`,
+        u.id,
+      ),
+      bd.primeiro<LinhaContagemItens>(
+        `SELECT COUNT(*) AS total_itens FROM patrimonio_itens WHERE usuario_id = ?`, u.id,
+      ),
+    ]);
+    const historicoReconstruido = reconstruirHistoricoDeMovimentos(
+      movimentos,
+      anoMes,
+      itens?.total_itens ?? 0,
+    );
+    for (const item of historicoReconstruido) {
+      await bd.executar(
+        `INSERT INTO patrimonio_historico_mensal (
+            usuario_id, ano_mes, patrimonio_bruto_brl, patrimonio_liquido_brl,
+            divida_brl, aporte_mes_brl, rentabilidade_mes_pct, eh_confiavel,
+            dados_json, atualizado_em
+          ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+         ON CONFLICT(usuario_id, ano_mes) DO UPDATE SET
+            patrimonio_bruto_brl = excluded.patrimonio_bruto_brl,
+            patrimonio_liquido_brl = excluded.patrimonio_liquido_brl,
+            divida_brl = excluded.divida_brl,
+            aporte_mes_brl = excluded.aporte_mes_brl,
+            rentabilidade_mes_pct = NULL,
+            eh_confiavel = excluded.eh_confiavel,
+            dados_json = excluded.dados_json,
+            atualizado_em = excluded.atualizado_em`,
+        u.id, item.anoMes, item.patrimonioBrutoBrl, item.patrimonioLiquidoBrl,
+        item.dividaBrl, item.aporteMesBrl, item.ehConfiavel ? 1 : 0,
+        item.dadosJson, timestamp,
+      );
+    }
+
     const resumo = await bd.primeiro<LinhaResumo>(
       `SELECT patrimonio_bruto_brl, divida_brl, patrimonio_liquido_brl, aporte_mes_brl
          FROM vw_patrimonio_resumo WHERE usuario_id = ?`,

--- a/servidores/porta-entrada/src/jobs/patrimonio-historico.movimentos.ts
+++ b/servidores/porta-entrada/src/jobs/patrimonio-historico.movimentos.ts
@@ -1,0 +1,91 @@
+export interface MovimentoHistorico {
+  item_id: string;
+  item_tipo: string;
+  tipo: string;
+  valor_brl: number | null;
+  data: string;
+  criado_em: string;
+}
+
+export interface SnapshotReconstruido {
+  anoMes: string;
+  patrimonioBrutoBrl: number;
+  patrimonioLiquidoBrl: number;
+  dividaBrl: number;
+  aporteMesBrl: number;
+  ehConfiavel: boolean;
+  dadosJson: string;
+}
+
+const mesSeguinte = (anoMes: string): string => {
+  const [ano, mes] = anoMes.split('-').map(Number);
+  return mes === 12 ? `${ano + 1}-01` : `${ano}-${String(mes + 1).padStart(2, '0')}`;
+};
+
+const mesesEntre = (primeiro: string, ultimoExclusivo: string): string[] => {
+  const meses: string[] = [];
+  for (let atual = primeiro; atual < ultimoExclusivo; atual = mesSeguinte(atual)) meses.push(atual);
+  return meses;
+};
+
+const MAX_MESES_RECONSTRUIDOS = 24;
+
+// Cada movimento registra o estado conhecido da posição naquele instante. Para
+// cada fechamento mensal, usa-se o último evento de cada item, sem projetar
+// valores para meses anteriores ao primeiro movimento.
+export const reconstruirHistoricoDeMovimentos = (
+  movimentos: MovimentoHistorico[],
+  anoMesAtual: string,
+  totalItens: number,
+): SnapshotReconstruido[] => {
+  if (movimentos.length === 0) return [];
+  const ordenados = [...movimentos].sort((a, b) =>
+    a.data.localeCompare(b.data) || a.criado_em.localeCompare(b.criado_em));
+  const primeiroMes = ordenados[0].data.slice(0, 7);
+  const itensComMovimento = new Set(ordenados.map((movimento) => movimento.item_id));
+  const itensSemMovimento = Math.max(0, totalItens - itensComMovimento.size);
+  const coberturaCompleta = itensSemMovimento === 0;
+
+  // O endpoint já entrega 24 meses; limitar a reconstrução preserva a quota D1
+  // quando houver importações muito antigas ou carteiras extensas.
+  return mesesEntre(primeiroMes, anoMesAtual).slice(-MAX_MESES_RECONSTRUIDOS).map((anoMes) => {
+    const limite = `${anoMes}-31`;
+    const ultimoPorItem = new Map<string, MovimentoHistorico>();
+    let aporteMesBrl = 0;
+    for (const movimento of ordenados) {
+      if (movimento.data > limite) break;
+      ultimoPorItem.set(movimento.item_id, movimento);
+      if (movimento.data.slice(0, 7) === anoMes && movimento.tipo === 'aporte') {
+        aporteMesBrl += movimento.valor_brl ?? 0;
+      }
+    }
+
+    let patrimonioBrutoBrl = 0;
+    let dividaBrl = 0;
+    let itensSemValor = 0;
+    for (const movimento of ultimoPorItem.values()) {
+      if (movimento.tipo === 'retirada') continue;
+      if (movimento.valor_brl === null) {
+        itensSemValor += 1;
+        continue;
+      }
+      if (movimento.item_tipo === 'divida') dividaBrl += movimento.valor_brl;
+      else patrimonioBrutoBrl += movimento.valor_brl;
+    }
+    const ehConfiavel = coberturaCompleta && itensSemValor === 0;
+    return {
+      anoMes,
+      patrimonioBrutoBrl,
+      patrimonioLiquidoBrl: patrimonioBrutoBrl - dividaBrl,
+      dividaBrl,
+      aporteMesBrl,
+      ehConfiavel,
+      dadosJson: JSON.stringify({
+        fonte: 'movimentos',
+        itensComMovimento: itensComMovimento.size,
+        itensSemMovimento,
+        itensSemValor,
+      }),
+    };
+  });
+};

--- a/servidores/porta-entrada/testes/historico-mensal.job.test.ts
+++ b/servidores/porta-entrada/testes/historico-mensal.job.test.ts
@@ -10,7 +10,7 @@ test('snapshot mensal reduz a confiança quando há cotação expirada', async (
       return {
         bind(...valores: unknown[]) {
           return {
-            all: async () => ({ results: [{ id: 'usuario-1' }] }),
+            all: async () => ({ results: sql.includes('FROM patrimonio_movimentos') ? [] : [{ id: 'usuario-1' }] }),
             first: async () => sql.includes('vw_patrimonio_resumo')
               ? { patrimonio_bruto_brl: 100, patrimonio_liquido_brl: 100, divida_brl: 0, aporte_mes_brl: 0 }
               : { total_itens: 2, itens_sem_valor: 0, itens_cotacao_expirada: 1 },

--- a/servidores/porta-entrada/testes/patrimonio-historico.movimentos.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-historico.movimentos.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { reconstruirHistoricoDeMovimentos } from '../src/jobs/patrimonio-historico.movimentos';
+
+test('reconstrói o fechamento mensal pelo último movimento de cada posição', () => {
+  const snapshots = reconstruirHistoricoDeMovimentos([
+    { item_id: 'acao-1', item_tipo: 'acao', tipo: 'compra', valor_brl: 100, data: '2026-01-10', criado_em: '2026-01-10T10:00:00Z' },
+    { item_id: 'fundo-1', item_tipo: 'fundo', tipo: 'aporte', valor_brl: 50, data: '2026-02-05', criado_em: '2026-02-05T10:00:00Z' },
+    { item_id: 'acao-1', item_tipo: 'acao', tipo: 'correcao', valor_brl: 120, data: '2026-02-20', criado_em: '2026-02-20T10:00:00Z' },
+    { item_id: 'acao-1', item_tipo: 'acao', tipo: 'retirada', valor_brl: 120, data: '2026-03-01', criado_em: '2026-03-01T10:00:00Z' },
+  ], '2026-04', 2);
+
+  assert.equal(snapshots.length, 3);
+  assert.deepEqual(snapshots.map(({ anoMes, patrimonioBrutoBrl, aporteMesBrl, ehConfiavel }) => ({ anoMes, patrimonioBrutoBrl, aporteMesBrl, ehConfiavel })), [
+    { anoMes: '2026-01', patrimonioBrutoBrl: 100, aporteMesBrl: 0, ehConfiavel: true },
+    { anoMes: '2026-02', patrimonioBrutoBrl: 170, aporteMesBrl: 50, ehConfiavel: true },
+    { anoMes: '2026-03', patrimonioBrutoBrl: 50, aporteMesBrl: 0, ehConfiavel: true },
+  ]);
+});
+
+test('marca a reconstrução como incompleta quando há posição sem movimento', () => {
+  const [snapshot] = reconstruirHistoricoDeMovimentos([
+    { item_id: 'acao-1', item_tipo: 'acao', tipo: 'compra', valor_brl: 100, data: '2026-01-10', criado_em: '2026-01-10T10:00:00Z' },
+  ], '2026-02', 2);
+  assert.equal(snapshot.ehConfiavel, false);
+  assert.deepEqual(JSON.parse(snapshot.dadosJson), {
+    fonte: 'movimentos', itensComMovimento: 1, itensSemMovimento: 1, itensSemValor: 0,
+  });
+});


### PR DESCRIPTION
## Alterações

- reconstrói os fechamentos de meses anteriores pelo último movimento de cada posição;
- trata retirada como posição zerada;
- registra aportes do mês;
- marca o snapshot como incompleto se existir posição sem movimento.

## Limites operacionais

A reconstrução é limitada aos últimos 24 meses, usa upsert por usuário e mês e não reativa os crons atualmente desabilitados.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (18 testes)