### PR TITLE
Controla reconstrução histórica por usuário

### DIFF
--- a/bibliotecas/contratos/patrimonio.ts
+++ b/bibliotecas/contratos/patrimonio.ts
@@ -110,6 +110,11 @@ export interface HistoricoMensalSaida {
   itens: HistoricoMensalItem[];
 }
 
+export interface ReconstrucaoHistoricoSaida {
+  mesesReconstruidos: number;
+  mesesConfiaveis: number;
+}
+
 export interface AlocacaoClasse {
   tipo: string;
   classe: string | null;

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.rotas.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.rotas.ts
@@ -41,6 +41,7 @@ export async function rotearPatrimonio(
   if (mAporte && metodo === 'DELETE') return servico.removerAporte(sessao.usuarioId, mAporte[1]);
 
   if (caminho === '/api/patrimonio/historico' && metodo === 'GET') return servico.historico(sessao.usuarioId);
+  if (caminho === '/api/patrimonio/historico/reconstruir' && metodo === 'POST') return servico.reconstruirHistorico(sessao.usuarioId);
   if (caminho === '/api/patrimonio/score' && metodo === 'GET') return servico.score(sessao.usuarioId);
 
   if (caminho === '/api/patrimonio/importacoes' && metodo === 'POST') {

--- a/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
+++ b/servidores/porta-entrada/src/dominios/patrimonio/patrimonio.servico.ts
@@ -7,6 +7,7 @@ import type {
   TipoItemPatrimonio, OrigemItemPatrimonio,
   ImportacaoSaida, ImportacaoCriarEntrada, ImportacaoConfirmarSaida,
   MovimentoPatrimonialSaida, TipoMovimentoPatrimonial,
+  ReconstrucaoHistoricoSaida,
 } from '@ei/contratos';
 import type { Bd } from '../../infra/bd';
 import { gerarId } from '../../infra/bd';
@@ -17,6 +18,7 @@ import {
   type LinhaEvolucao, type LinhaPosicao, type LinhaResumo, type LinhaScoreAtual,
   type LinhaMovimentoPatrimonial,
 } from './patrimonio.repositorio';
+import { reconstruirHistoricoPorMovimentosUsuario } from '../../jobs/historico-mensal.job';
 
 const paraItemSaida = (l: LinhaPosicao, totalBrl: number): ItemPatrimonioSaida => {
   const valor = l.valor_atual_brl ?? 0;
@@ -258,6 +260,10 @@ export const servicoPatrimonio = (bd: Bd) => {
       if (!item) return erro('item_nao_encontrado', 'Item de patrimônio não encontrado', 404);
       const movimentos = await repo.listarMovimentosItem(usuarioId, itemId);
       return sucesso({ itens: movimentos.map(paraMovimentoSaida) });
+    },
+
+    async reconstruirHistorico(usuarioId: string): Promise<ServiceResponse<ReconstrucaoHistoricoSaida>> {
+      return sucesso(await reconstruirHistoricoPorMovimentosUsuario(bd, usuarioId));
     },
 
     async criarItem(usuarioId: string, e: ItemPatrimonioCriarEntrada): Promise<ServiceResponse<ItemPatrimonioSaida>> {

--- a/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
+++ b/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
@@ -3,7 +3,7 @@
 // (usuario_id, ano_mes) garante que rodar múltiplas vezes no mesmo mês
 // apenas atualiza a linha correspondente.
 
-import type { Env } from '../infra/bd';
+import type { Bd, Env } from '../infra/bd';
 import { agora, criarBd } from '../infra/bd';
 import { reconstruirHistoricoDeMovimentos, type MovimentoHistorico } from './patrimonio-historico.movimentos';
 
@@ -28,6 +28,53 @@ interface LinhaContagemItens {
   total_itens: number;
 }
 
+export async function reconstruirHistoricoPorMovimentosUsuario(
+  bd: Bd,
+  usuarioId: string,
+  anoMes = new Date().toISOString().slice(0, 7),
+  timestamp = agora(),
+): Promise<{ mesesReconstruidos: number; mesesConfiaveis: number }> {
+  const [movimentos, itens] = await Promise.all([
+    bd.consultar<MovimentoHistorico>(
+      `SELECT m.item_id, i.tipo AS item_tipo, m.tipo, m.valor_brl, m.data, m.criado_em
+         FROM patrimonio_movimentos m
+         INNER JOIN patrimonio_itens i ON i.id = m.item_id
+        WHERE m.usuario_id = ?
+        ORDER BY m.data ASC, m.criado_em ASC`,
+      usuarioId,
+    ),
+    bd.primeiro<LinhaContagemItens>(
+      `SELECT COUNT(*) AS total_itens FROM patrimonio_itens WHERE usuario_id = ?`, usuarioId,
+    ),
+  ]);
+  const historicoReconstruido = reconstruirHistoricoDeMovimentos(movimentos, anoMes, itens?.total_itens ?? 0);
+  for (const item of historicoReconstruido) {
+    await bd.executar(
+      `INSERT INTO patrimonio_historico_mensal (
+          usuario_id, ano_mes, patrimonio_bruto_brl, patrimonio_liquido_brl,
+          divida_brl, aporte_mes_brl, rentabilidade_mes_pct, eh_confiavel,
+          dados_json, atualizado_em
+        ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+       ON CONFLICT(usuario_id, ano_mes) DO UPDATE SET
+          patrimonio_bruto_brl = excluded.patrimonio_bruto_brl,
+          patrimonio_liquido_brl = excluded.patrimonio_liquido_brl,
+          divida_brl = excluded.divida_brl,
+          aporte_mes_brl = excluded.aporte_mes_brl,
+          rentabilidade_mes_pct = NULL,
+          eh_confiavel = excluded.eh_confiavel,
+          dados_json = excluded.dados_json,
+          atualizado_em = excluded.atualizado_em`,
+      usuarioId, item.anoMes, item.patrimonioBrutoBrl, item.patrimonioLiquidoBrl,
+      item.dividaBrl, item.aporteMesBrl, item.ehConfiavel ? 1 : 0,
+      item.dadosJson, timestamp,
+    );
+  }
+  return {
+    mesesReconstruidos: historicoReconstruido.length,
+    mesesConfiaveis: historicoReconstruido.filter((item) => item.ehConfiavel).length,
+  };
+}
+
 export async function historicoMensalJob(env: Env): Promise<void> {
   const bd = criarBd(env);
   const usuarios = await bd.consultar<LinhaUsuario>(`SELECT id FROM usuarios`);
@@ -37,45 +84,7 @@ export async function historicoMensalJob(env: Env): Promise<void> {
   const timestamp = agora();
 
   for (const u of usuarios) {
-    const [movimentos, itens] = await Promise.all([
-      bd.consultar<MovimentoHistorico>(
-        `SELECT m.item_id, i.tipo AS item_tipo, m.tipo, m.valor_brl, m.data, m.criado_em
-           FROM patrimonio_movimentos m
-           INNER JOIN patrimonio_itens i ON i.id = m.item_id
-          WHERE m.usuario_id = ?
-          ORDER BY m.data ASC, m.criado_em ASC`,
-        u.id,
-      ),
-      bd.primeiro<LinhaContagemItens>(
-        `SELECT COUNT(*) AS total_itens FROM patrimonio_itens WHERE usuario_id = ?`, u.id,
-      ),
-    ]);
-    const historicoReconstruido = reconstruirHistoricoDeMovimentos(
-      movimentos,
-      anoMes,
-      itens?.total_itens ?? 0,
-    );
-    for (const item of historicoReconstruido) {
-      await bd.executar(
-        `INSERT INTO patrimonio_historico_mensal (
-            usuario_id, ano_mes, patrimonio_bruto_brl, patrimonio_liquido_brl,
-            divida_brl, aporte_mes_brl, rentabilidade_mes_pct, eh_confiavel,
-            dados_json, atualizado_em
-          ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
-         ON CONFLICT(usuario_id, ano_mes) DO UPDATE SET
-            patrimonio_bruto_brl = excluded.patrimonio_bruto_brl,
-            patrimonio_liquido_brl = excluded.patrimonio_liquido_brl,
-            divida_brl = excluded.divida_brl,
-            aporte_mes_brl = excluded.aporte_mes_brl,
-            rentabilidade_mes_pct = NULL,
-            eh_confiavel = excluded.eh_confiavel,
-            dados_json = excluded.dados_json,
-            atualizado_em = excluded.atualizado_em`,
-        u.id, item.anoMes, item.patrimonioBrutoBrl, item.patrimonioLiquidoBrl,
-        item.dividaBrl, item.aporteMesBrl, item.ehConfiavel ? 1 : 0,
-        item.dadosJson, timestamp,
-      );
-    }
+    await reconstruirHistoricoPorMovimentosUsuario(bd, u.id, anoMes, timestamp);
 
     const resumo = await bd.primeiro<LinhaResumo>(
       `SELECT patrimonio_bruto_brl, divida_brl, patrimonio_liquido_brl, aporte_mes_brl

--- a/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
+++ b/servidores/porta-entrada/testes/patrimonio-cnpj.servico.test.ts
@@ -252,3 +252,25 @@ test('lista somente os movimentos do item do usuário autenticado', async () => 
     dadosJson: { aba: 'acoes' }, criadoEm: '2026-07-20T10:00:00.000Z',
   });
 });
+
+test('reconstrói somente o histórico do usuário autenticado', async () => {
+  const execucoes: { sql: string; valores: unknown[] }[] = [];
+  const bd = {
+    consultar: async (sql: string) => sql.includes('FROM patrimonio_movimentos') ? [{
+      item_id: 'item-1', item_tipo: 'acao', tipo: 'compra', valor_brl: 100, data: '2026-01-10', criado_em: '2026-01-10T10:00:00Z',
+    }] : [],
+    primeiro: async () => ({ total_itens: 1 }),
+    executar: async (sql: string, ...valores: unknown[]) => {
+      execucoes.push({ sql, valores });
+      return { sucesso: true, linhasAfetadas: 1 };
+    },
+    emLote: async () => {},
+  };
+  const resultado = await servicoPatrimonio(bd).reconstruirHistorico('usuario-1');
+  assert.equal(resultado.ok, true, JSON.stringify(resultado));
+  if (!resultado.ok) return;
+  assert.equal(resultado.dados.mesesReconstruidos, 6);
+  assert.equal(resultado.dados.mesesConfiaveis, 6);
+  assert.equal(execucoes.length, 6);
+  assert.ok(execucoes.every((execucao) => execucao.valores[0] === 'usuario-1'));
+});


### PR DESCRIPTION
## Alterações

- expõe POST /api/patrimonio/historico/reconstruir para a sessão autenticada;
- reconstrói somente os próprios meses históricos e informa quantidade e confiabilidade;
- compartilha a mesma rotina idempotente usada pelo job mensal.

## Limites operacionais

A operação é limitada aos últimos 24 meses, não percorre usuários de terceiros e não reativa crons.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (19 testes)