### PR TITLE
Observa execuções de jobs

### DIFF
--- a/infra/banco/migrations/104_observar_execucoes_jobs.sql
+++ b/infra/banco/migrations/104_observar_execucoes_jobs.sql
@@ -1,0 +1,13 @@
+CREATE TABLE job_execucoes (
+  id TEXT PRIMARY KEY,
+  nome TEXT NOT NULL,
+  status TEXT NOT NULL CHECK(status IN ('executando', 'concluido', 'falhou')),
+  iniciado_em TEXT NOT NULL,
+  concluido_em TEXT,
+  duracao_ms INTEGER,
+  volume INTEGER,
+  erro TEXT
+);
+
+CREATE INDEX idx_job_execucoes_nome_inicio
+  ON job_execucoes(nome, iniciado_em DESC);

--- a/servidores/porta-entrada/src/index.ts
+++ b/servidores/porta-entrada/src/index.ts
@@ -6,6 +6,7 @@ import { ehRotaPublica, ehTokenServicoCvm, resolverSessao, rotear } from "./apli
 import { atualizarMercadoJob } from "./jobs/mercado-atualizar.job";
 import { historicoMensalJob } from "./jobs/historico-mensal.job";
 import { patrimonioReconstruirJob } from "./jobs/patrimonio-reconstruir.job";
+import { executarJobMonitorado } from "./jobs/observabilidade.job";
 
 export type { Env };
 
@@ -99,13 +100,19 @@ export default {
 
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
     if (event.cron === "0 3 * * *") {
-      ctx.waitUntil(historicoMensalJob(env).catch(() => {}));
+      ctx.waitUntil(executarJobMonitorado(env, 'historico_mensal', () => historicoMensalJob(env)).catch((causa) => {
+        console.error('cron_historico_mensal_falhou', causa);
+      }));
       return;
     }
     if (event.cron === "*/30 * * * *") {
-      ctx.waitUntil(patrimonioReconstruirJob(env).catch(() => {}));
+      ctx.waitUntil(executarJobMonitorado(env, 'patrimonio_reconstrucao', () => patrimonioReconstruirJob(env)).catch((causa) => {
+        console.error('cron_patrimonio_reconstrucao_falhou', causa);
+      }));
       return;
     }
-    ctx.waitUntil(atualizarMercadoJob(env).catch(() => {}));
+    ctx.waitUntil(executarJobMonitorado(env, 'mercado_atualizar', () => atualizarMercadoJob(env)).catch((causa) => {
+      console.error('cron_mercado_atualizar_falhou', causa);
+    }));
   },
 };

--- a/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
+++ b/servidores/porta-entrada/src/jobs/historico-mensal.job.ts
@@ -75,16 +75,18 @@ export async function reconstruirHistoricoPorMovimentosUsuario(
   };
 }
 
-export async function historicoMensalJob(env: Env): Promise<void> {
+export async function historicoMensalJob(env: Env): Promise<number> {
   const bd = criarBd(env);
   const usuarios = await bd.consultar<LinhaUsuario>(`SELECT id FROM usuarios`);
-  if (usuarios.length === 0) return;
+  if (usuarios.length === 0) return 0;
 
   const anoMes = new Date().toISOString().slice(0, 7);
   const timestamp = agora();
+  let gravacoes = 0;
 
   for (const u of usuarios) {
-    await reconstruirHistoricoPorMovimentosUsuario(bd, u.id, anoMes, timestamp);
+    const reconstruido = await reconstruirHistoricoPorMovimentosUsuario(bd, u.id, anoMes, timestamp);
+    gravacoes += reconstruido.mesesReconstruidos;
 
     const resumo = await bd.primeiro<LinhaResumo>(
       `SELECT patrimonio_bruto_brl, divida_brl, patrimonio_liquido_brl, aporte_mes_brl
@@ -140,5 +142,7 @@ export async function historicoMensalJob(env: Env): Promise<void> {
       dadosJson,
       timestamp,
     );
+    gravacoes += 1;
   }
+  return gravacoes;
 }

--- a/servidores/porta-entrada/src/jobs/mercado-atualizar.job.ts
+++ b/servidores/porta-entrada/src/jobs/mercado-atualizar.job.ts
@@ -11,7 +11,7 @@ interface LinhaAtivoUsado {
   tipo: string;
 }
 
-export async function atualizarMercadoJob(env: Env): Promise<void> {
+export async function atualizarMercadoJob(env: Env): Promise<number> {
   const bd = criarBd(env);
   const ativos = await bd.consultar<LinhaAtivoUsado>(
     `SELECT DISTINCT a.id, a.ticker, a.cnpj, a.tipo
@@ -20,11 +20,12 @@ export async function atualizarMercadoJob(env: Env): Promise<void> {
       WHERE p.esta_ativo = 1`,
   );
 
-  if (ativos.length === 0) return;
+  if (ativos.length === 0) return 0;
 
   const timestamp = agora();
   const expira = new Date(Date.now() + 5 * 60_000).toISOString();
 
+  let atualizados = 0;
   for (const ativo of ativos) {
     const preco = await buscarPreco(ativo, env, bd);
     if (preco == null) continue;
@@ -43,7 +44,9 @@ export async function atualizarMercadoJob(env: Env): Promise<void> {
       expira,
       JSON.stringify({ origem: 'job', tipo: ativo.tipo, referenciaEm: preco.referenciaEm ?? timestamp }),
     );
+    atualizados += 1;
   }
+  return atualizados;
 }
 
 function fontePara(tipo: string): string {

--- a/servidores/porta-entrada/src/jobs/observabilidade.job.ts
+++ b/servidores/porta-entrada/src/jobs/observabilidade.job.ts
@@ -1,0 +1,36 @@
+import type { Env } from '../infra/bd';
+import { agora, criarBd, gerarId } from '../infra/bd';
+
+export async function executarJobMonitorado(
+  env: Env,
+  nome: string,
+  executar: () => Promise<number>,
+): Promise<void> {
+  const bd = criarBd(env);
+  const id = gerarId();
+  const iniciadoEm = agora();
+  const iniciadoMs = Date.now();
+  await bd.executar(
+    `INSERT INTO job_execucoes (id, nome, status, iniciado_em) VALUES (?, ?, 'executando', ?)`,
+    id, nome, iniciadoEm,
+  );
+  try {
+    const volume = await executar();
+    await bd.executar(
+      `UPDATE job_execucoes
+          SET status = 'concluido', concluido_em = ?, duracao_ms = ?, volume = ?
+        WHERE id = ?`,
+      agora(), Date.now() - iniciadoMs, volume, id,
+    );
+  } catch (causa) {
+    const erro = String(causa instanceof Error ? causa.message : causa).slice(0, 1000);
+    await bd.executar(
+      `UPDATE job_execucoes
+          SET status = 'falhou', concluido_em = ?, duracao_ms = ?, erro = ?
+        WHERE id = ?`,
+      agora(), Date.now() - iniciadoMs, erro, id,
+    );
+    console.error('job_falhou', { nome, id, erro });
+    throw causa;
+  }
+}

--- a/servidores/porta-entrada/src/jobs/patrimonio-reconstruir.job.ts
+++ b/servidores/porta-entrada/src/jobs/patrimonio-reconstruir.job.ts
@@ -17,15 +17,16 @@ interface LinhaItemComPreco {
   preco_atual_brl: number | null;
 }
 
-export async function patrimonioReconstruirJob(env: Env): Promise<void> {
+export async function patrimonioReconstruirJob(env: Env): Promise<number> {
   const bd = criarBd(env);
   const fila = await bd.consultar<LinhaFila>(
     `SELECT id, usuario_id FROM patrimonio_fila_reconstrucao
       WHERE status = 'pendente' ORDER BY agendado_em ASC LIMIT 50`,
   );
-  if (fila.length === 0) return;
+  if (fila.length === 0) return 0;
 
   const timestamp = agora();
+  let processadas = 0;
 
   for (const tarefa of fila) {
     try {
@@ -34,6 +35,7 @@ export async function patrimonioReconstruirJob(env: Env): Promise<void> {
         timestamp,
         tarefa.id,
       );
+      processadas += 1;
 
       const itens = await bd.consultar<LinhaItemComPreco>(
         `SELECT p.id, p.quantidade, p.preco_medio_brl,
@@ -70,4 +72,5 @@ export async function patrimonioReconstruirJob(env: Env): Promise<void> {
       );
     }
   }
+  return processadas;
 }

--- a/servidores/porta-entrada/testes/observabilidade.job.test.ts
+++ b/servidores/porta-entrada/testes/observabilidade.job.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { Env } from '../src/infra/bd';
+import { executarJobMonitorado } from '../src/jobs/observabilidade.job';
+
+test('registra sucesso, duração e volume de um job', async () => {
+  const execucoes: { sql: string; valores: unknown[] }[] = [];
+  const bd = {
+    prepare(sql: string) {
+      return { bind: (...valores: unknown[]) => ({
+        all: async () => ({ results: [] }),
+        first: async () => null,
+        run: async () => {
+          execucoes.push({ sql, valores });
+          return { success: true, meta: { changes: 1 } };
+        },
+      }) };
+    },
+    batch: async () => [],
+  };
+  await executarJobMonitorado({ DB: bd } as unknown as Env, 'teste', async () => 7);
+  assert.match(execucoes[0].sql, /INSERT INTO job_execucoes/);
+  assert.match(execucoes[1].sql, /status = 'concluido'/);
+  assert.equal(execucoes[1].valores[2], 7);
+});
+
+test('registra falha antes de propagar o erro do job', async () => {
+  const execucoes: { sql: string; valores: unknown[] }[] = [];
+  const bd = {
+    prepare(sql: string) {
+      return { bind: (...valores: unknown[]) => ({
+        all: async () => ({ results: [] }), first: async () => null,
+        run: async () => { execucoes.push({ sql, valores }); return { success: true, meta: { changes: 1 } }; },
+      }) };
+    },
+    batch: async () => [],
+  };
+  await assert.rejects(
+    executarJobMonitorado({ DB: bd } as unknown as Env, 'teste', async () => { throw new Error('indisponível'); }),
+    /indisponível/,
+  );
+  assert.match(execucoes[1].sql, /status = 'falhou'/);
+  assert.equal(execucoes[1].valores[2], 'indisponível');
+});


### PR DESCRIPTION
## Alterações

- registra início, sucesso/falha, duração e volume dos jobs críticos;
- substitui capturas silenciosas de erro por registro persistente e log estruturado;
- adiciona migration 104, já aplicada e verificada no D1 compartilhado.

## Limites operacionais

Os cron jobs permanecem desativados por limite de gatilhos da conta; esta mudança não cria execução automática adicional.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (21 testes)