### PR TITLE
Expõe saúde dos jobs ao admin

### DIFF
--- a/bibliotecas/contratos/admin.ts
+++ b/bibliotecas/contratos/admin.ts
@@ -36,3 +36,14 @@ export interface AdminIngestaoCvmItem {
   resultadoJson: Record<string, unknown>;
   erro: string | null;
 }
+
+export interface AdminJobExecucaoItem {
+  id: string;
+  nome: string;
+  status: 'executando' | 'concluido' | 'falhou';
+  iniciadoEm: string;
+  concluidoEm: string | null;
+  duracaoMs: number | null;
+  volume: number | null;
+  erro: string | null;
+}

--- a/servidores/porta-entrada/src/dominios/admin/admin.repositorio.ts
+++ b/servidores/porta-entrada/src/dominios/admin/admin.repositorio.ts
@@ -29,6 +29,11 @@ export interface LinhaIngestaoCvm {
   erro: string | null;
 }
 
+export interface LinhaJobExecucao {
+  id: string; nome: string; status: string; iniciado_em: string; concluido_em: string | null;
+  duracao_ms: number | null; volume: number | null; erro: string | null;
+}
+
 export const repositorioAdmin = (bd: Bd) => ({
   async ehAdmin(email: string): Promise<boolean> {
     const l = await bd.primeiro<{ email: string }>(
@@ -57,6 +62,13 @@ export const repositorioAdmin = (bd: Bd) => ({
     return bd.consultar<LinhaIngestaoCvm>(
       `SELECT * FROM vw_admin_ingestao_cvm ORDER BY iniciado_em DESC LIMIT ?`,
       limite,
+    );
+  },
+
+  async execucoesJobs(limite = 50): Promise<LinhaJobExecucao[]> {
+    return bd.consultar<LinhaJobExecucao>(
+      `SELECT id, nome, status, iniciado_em, concluido_em, duracao_ms, volume, erro
+         FROM job_execucoes ORDER BY iniciado_em DESC LIMIT ?`, limite,
     );
   },
 

--- a/servidores/porta-entrada/src/dominios/admin/admin.rotas.ts
+++ b/servidores/porta-entrada/src/dominios/admin/admin.rotas.ts
@@ -68,6 +68,7 @@ export async function rotearAdmin(
   if (caminho === '/api/admin/usuarios' && metodo === 'GET') return servico.listarUsuarios(sessao.email);
   if (caminho === '/api/admin/auditoria' && metodo === 'GET') return servico.auditoria(sessao.email);
   if (caminho === '/api/admin/cvm' && metodo === 'GET') return servico.ingestoesCvm(sessao.email);
+  if (caminho === '/api/admin/jobs' && metodo === 'GET') return servico.execucoesJobs(sessao.email);
 
   return caminho.startsWith('/api/admin') ? naoEncontrado() : metodoNaoPermitido(metodo);
 }

--- a/servidores/porta-entrada/src/dominios/admin/admin.servico.ts
+++ b/servidores/porta-entrada/src/dominios/admin/admin.servico.ts
@@ -1,12 +1,13 @@
 import type {
   AdminEntrarEntrada, AdminUsuarioSaida, AdminAuditoriaItem, AdminIngestaoCvmItem,
   TokenSaida, IngestaoCvmModo, IngestaoCvmStatus,
+  AdminJobExecucaoItem,
 } from '@ei/contratos';
 import type { Bd, Env } from '../../infra/bd';
 import { emitirToken, validarSenha } from '../../infra/cripto';
 import { erro, sucesso, type ServiceResponse } from '../../infra/http';
 import { repositorioAuth } from '../auth/auth.repositorio';
-import { repositorioAdmin, type LinhaAuditoria, type LinhaIngestaoCvm } from './admin.repositorio';
+import { repositorioAdmin, type LinhaAuditoria, type LinhaIngestaoCvm, type LinhaJobExecucao } from './admin.repositorio';
 
 const paraAuditoria = (l: LinhaAuditoria): AdminAuditoriaItem => ({
   id: l.id,
@@ -27,6 +28,11 @@ const paraIngestao = (l: LinhaIngestaoCvm): AdminIngestaoCvmItem => ({
   parametrosJson: (() => { try { return JSON.parse(l.parametros_json); } catch { return {}; } })(),
   resultadoJson: (() => { try { return JSON.parse(l.resultado_json); } catch { return {}; } })(),
   erro: l.erro,
+});
+
+const paraExecucaoJob = (l: LinhaJobExecucao): AdminJobExecucaoItem => ({
+  id: l.id, nome: l.nome, status: l.status as AdminJobExecucaoItem['status'], iniciadoEm: l.iniciado_em,
+  concluidoEm: l.concluido_em, duracaoMs: l.duracao_ms, volume: l.volume, erro: l.erro,
 });
 
 export const servicoAdmin = (bd: Bd, env: Env) => {
@@ -65,6 +71,11 @@ export const servicoAdmin = (bd: Bd, env: Env) => {
       if (!(await repo.ehAdmin(sessaoEmail))) return erro('sem_permissao', 'Acesso administrativo negado', 403);
       const linhas = await repo.ingestoesCvm();
       return sucesso({ itens: linhas.map(paraIngestao) });
+    },
+
+    async execucoesJobs(sessaoEmail: string): Promise<ServiceResponse<{ itens: AdminJobExecucaoItem[] }>> {
+      if (!(await repo.ehAdmin(sessaoEmail))) return erro('sem_permissao', 'Acesso administrativo negado', 403);
+      return sucesso({ itens: (await repo.execucoesJobs()).map(paraExecucaoJob) });
     },
   };
 };


### PR DESCRIPTION
## Alterações

- adiciona GET /api/admin/jobs para sessões administrativas;
- expõe status, duração, volume e erro das execuções registradas;
- mantém a proteção administrativa já existente.

## Validação

- npm.cmd run typecheck
- npm.cmd run test:api (22 testes)