### PR TITLE
Inventaria v1 e vera-insights na Onda 5 de encerramento de _legacy

### DIFF
--- a/documentacao/consolidacao/AUDITORIA_CONSOLIDACAO_PRODUTO_UNICO.md
+++ b/documentacao/consolidacao/AUDITORIA_CONSOLIDACAO_PRODUTO_UNICO.md
@@ -217,3 +217,89 @@ A consolidação estará concluída quando:
 ## 10. Prioridade imediata
 
 Não iniciar nova migração de tela. O próximo trabalho deve ser a Onda 0 e, em paralelo, a especificação executável da Onda 1. O produto já possui interface suficiente; falta garantir que todos os números exibidos tenham uma única origem e uma regra verificável.
+
+## 11. Onda 5 — Inventário e encerramento de `_legacy` (issue #115)
+
+Atualizado em: 2026-07-26. **Status: em andamento, não concluído.** Reconfirmado por grep que
+`apresentacao/src`, `servidores` e `bibliotecas` não importam nada de `_legacy` (nenhuma
+ocorrência da string `_legacy` fora da própria pasta).
+
+Cobertura desta rodada: **v1** e **vera-insights** inventariados por completo, item a item.
+**v2, bridge e quanto ainda não foram inventariados** — ver §11.5. Não fechar #115 até os cinco
+legados estarem cobertos e `_legacy` estar congelado.
+
+### 11.1 `_legacy/v1` — Esquilo Invest (Google Apps Script, dashboard estático)
+
+546 KB, 21 arquivos. HTML/CSS/JS servido via `doGet()` do Apps Script, lendo abas de uma planilha
+Google (`Dashboard`, `Acoes`, `Pré-Ordens`, `Fundos`, `Previdência`, `Recomendações`, `Aportes`) e
+com IA (ChatGPT/Gemini) para análise textual. Não executa ordens (nunca simulou compra/venda real).
+
+| Item | Classificação | Destino / evidência |
+|---|---|---|
+| Consolidação por categoria (Ações/Fundos/Previdência) com totais | Absorvido | `patrimonio_itens` + `vw_patrimonio_alocacao`, endpoint `GET /api/patrimonio/resumo` |
+| Ghost mode (ocultar valores sensíveis sem alterar dado em memória) | Absorvido | `apresentacao/src/components/base/ValorOcultavel.jsx` + `context/ModoVisualizacaoContext.jsx`, usado em Home/Carteira/Insights/Histórico |
+| Manifest PWA + ícones iOS/Android (`manifest.webmanifest`, apple-touch-icon) | Absorvido | `apresentacao/vite.config.ts` (`VitePWA`) + `apresentacao/public/manifest.webmanifest` próprio |
+| Ícone de instituição por lista hardcoded (Ion/Itaú/XP) | Descartado | Contraria regra de núcleo único sem hardcode de marca; raiz usa `corretoras` como tabela, não constante de código |
+| Score de portfólio: pilar de **diversificação por nº de instituições distintas** | Substituído | `calculos/score.ts` usa nº de classes de ativo (`numeroClassesAlocadas/5`), não nº de instituições — decisão já tomada na Onda 1, não é gap |
+| Score de portfólio: pilar de **performance** (retorno acumulado) e **consistência de aportes** | Substituído | `calculos/score.ts` pilar "disciplina" (razão aporte/renda) cobre consistência; performance de carteira vive em `calculos/rentabilidade.ts`, fora do score — separação intencional |
+| Score de portfólio: **concentração máxima em um único ativo** (`maxShare`) e **saúde por % de posições negativas** | **Pendente** | Ausente na raiz — nem `score.ts` nem `alocacao.ts` calculam concentração por ativo individual (só por classe) ou proporção de posições no vermelho. Candidato a evolução do pilar "diversificação" de `calculos/score.ts` quando Insights for revisado. Não implementado nesta sessão — sem necessidade confirmada, ver regra "não criar feature sem necessidade real" |
+| Perfil gamificado "Squad" (Conservador/Balanceado/Agressivo) + "Nível" 1-10 | Descartado | Linguagem de gamificação de v1, incompatível com a marca atual; perfil de investidor real já existe em `perfis_financeiros` |
+| Alertas de risco (stop-loss atingido, queda >5%/15%, concentração) | **Pendente** | Não existe conceito de alerta/aviso na raiz hoje (nem tabela, nem view, nem endpoint). Mesma lacuna do item de concentração acima — candidato a feature de Insights, não criar agora |
+| Recomendação tática por ativo (Vender/Revisar/Monitorar/Manter) | Descartado | Sugestão de trade individual está fora do escopo do produto (consolidação patrimonial, sem execução de ordens) — mesma limitação que v1 já declarava no seu próprio README |
+| IA lendo todas as abas da planilha em texto bruto no prompt | Descartado | Prática abandonada — PR #168 (contexto financeiro canônico) proíbe explicitamente a IA de receber ou recalcular dados brutos; usa resumo estruturado e versionado |
+| Chart URL para Google Finance por ticker | Descartado | Raiz tem provedor de cotação próprio (BRAPI) via `dominios/mercado/provedores/brapi.ts`, sem necessidade de link externo |
+| Auto-refresh do dashboard a cada 60s | Apenas referência | Sem gap funcional relevante hoje; não avaliado como prioridade |
+
+### 11.2 `_legacy/vera-insights` — motor Vera standalone (React/Express/Cloudflare Workers)
+
+1.1 MB, 77 arquivos. Protótipo de assistente financeiro com motor determinístico
+(`src/lib/vera/`, `src/lib/esquilo/`) e cascata de provedores de IA (Cloudflare AI → OpenAI →
+Gemini → Claude → fallback de regras). Relevância direta: é a origem conceitual do domínio
+`decisoes/vera` ativo hoje na raiz, hoje afetado pela decisão de descontinuar a Vera como produto
+(ver fechamento de #114).
+
+| Item | Classificação | Destino / evidência |
+|---|---|---|
+| `VeraCoreEngine.calculateDebtPressure` (pressão de dívida: serviço mensal + dívida cara/patrimônio líquido) | **Pendente** | Ausente na raiz. `calculos/score.ts` tem pilar "endividamento" com fórmula mais simples (dívida/patrimônio bruto). Candidato a evolução do pilar, não a novo cálculo paralelo — não implementado |
+| `VeraCoreEngine.calculateLiquidityAdequacy` (ativos líquidos / despesa × meses-alvo) | Substituído | `calculos/score.ts` pilar "proteção" já cobre o mesmo conceito (reserva em meses de renda) |
+| `VeraCoreEngine.evaluateGoals` (viabilidade de meta via PMT financeiro) | **Pendente** | Nenhum motor de cálculo real para metas/simulações na raiz — confirma o gap já flagueado no PR #168 ("Fora de escopo... 5 motores de cálculo é escopo novo, não decidido sozinho"). Não construir agora — já está registrado como decisão pendente do Luiz |
+| `PortfolioAnalysis`: concentração via índice de Herfindahl, risco 0-100 por perfil, retorno esperado/volatilidade/Sharpe, drift de alocação | **Pendente** | Ausente na raiz. `calculos/alocacao.ts` só calcula peso % por classe, sem concentração (Herfindahl), risco ou Sharpe. Mesma lacuna dos itens de concentração/alerta de v1 (§11.1) — não duplicar issue, é o mesmo gap visto por duas gerações diferentes |
+| `RecommendationEngine`, `NarrativeGenerator`, `GoalsNarrative` (texto gerado por regras, sem IA) | Descartado | Específico da UX de companion contínuo da Vera standalone; produto Vera descontinuado (decisão do Luiz). O princípio de "fallback determinístico sem IA" já foi absorvido de forma equivalente e mais simples no PR #168 |
+| Cascata de 4 provedores de IA (Cloudflare → OpenAI → Gemini → Claude) | Descartado | Raiz usa só o binding `AI` (Cloudflare Workers AI) com fallback determinístico único — decisão consciente de simplicidade operacional, não uma lacuna |
+| Behavioral tracking (`vera_behavioral`: aceito/ignorado/adiado/completo por recomendação) | Descartado | Específico do loop de acompanhamento contínuo da Vera como companion — produto descontinuado, sem consumidor no domínio atual |
+| `vera_snapshots` / `vera_monthly_trend` (histórico de score) | Substituído | `patrimonio_scores` + `patrimonio_historico_mensal` (idempotente, canônico) já cobrem histórico de score/patrimônio |
+| `vera_cache` / `vera_data_audit` (cache com TTL de dados externos + auditoria de frescor) | Substituído | `ativos_cotacoes_cache` (D1) + KV cache (`infra/cache.ts`) na raiz |
+| `BrapiClient`, `CvmClient`, `FipeClient` próprios | Substituído | `dominios/mercado/provedores/{brapi,cvm,fipe}.ts` |
+| Endpoint único `/api/analyze` retornando recomendação de compra/venda/troca por ativo | Descartado | Sugestão de trade individual fora do escopo do produto (mesma decisão do item equivalente em v1) |
+| `src/lib/studio/` (renderer.ts, store.ts) | Apenas referência | Sandbox de prototipagem visual, não avaliado em profundidade — sem sinal de valor de produto |
+| `.wrangler/state`, `esquilo_master_pack.zip`, `server.log`, scripts `test-*.sh`/`test-*.ts` na raiz do pacote | Descartado | Artefatos operacionais do protótipo, sem valor de produto ou histórico |
+
+### 11.3 Decisão já registrada (não reaberta aqui)
+
+O domínio `decisoes/vera` vivo hoje em `servidores/porta-entrada/src/dominios/decisoes/` **não foi
+tocado, removido ou marcado como legado** nesta sessão — a decisão do Luiz é que a Vera é
+descontinuada **como produto**, não uma instrução para desmontar o código ativo. Essa decisão de
+arquitetura (o que fazer com `decisoes/vera` daqui para frente) já está fora do escopo mecânico
+desta issue e cabe ao Luiz decidir quando quiser, conforme registrado no fechamento de #114.
+
+### 11.4 Padrão que se repete entre gerações
+
+Tanto v1 quanto vera-insights, de formas diferentes, tinham **concentração de risco (por ativo ou
+por Herfindahl) e alerta de risco** que a raiz não tem hoje. É a mesma lacuna vista duas vezes, não
+dois achados separados — se for priorizado, é uma única evolução do pilar "diversificação" de
+`calculos/score.ts` (ou um pilar novo), não duas issues.
+
+### 11.5 Trabalho restante da Onda 5 (não feito nesta sessão)
+
+- **`_legacy/v2`** (8.5 MB, 160 arquivos — Apps Script + BigQuery + app mobile Flutter) — não
+  inventariado.
+- **`_legacy/bridge`** (6.3 MB, 564 arquivos — pacote de migração Apps Script → Cloudflare/D1,
+  majoritariamente documentação de processo) — não inventariado.
+- **`_legacy/quanto`** (6.3 MB, 228 arquivos — app paralelo completo com backend, ingestão,
+  frontend e testes próprios) — já tem síntese em nível de matriz nas §§3-6 deste documento, mas
+  **não tem inventário item a item com ponteiro para código/contrato/teste/issue**, que é o que o
+  critério de aceite de #115 exige. Precisa de uma passada dedicada.
+- **Congelamento de `_legacy`** (CODEOWNERS ou nota read-only) — não aplicado ainda. Só deve ser
+  feito depois que os três legados acima também estiverem inventariados, para não travar um
+  ajuste de nota/classificação no meio do trabalho.
+- **Fechamento de #115** — não fazer até os cinco legados estarem cobertos e `_legacy` congelado.


### PR DESCRIPTION
## Contexto

Parte da Onda 5 (#115) do épico #109. Continuação após o fechamento de #114
(Vera descontinuada como produto).

## O que muda

Adiciona seção 11 em `documentacao/consolidacao/AUDITORIA_CONSOLIDACAO_PRODUTO_UNICO.md`
com inventário item a item de dois dos cinco legados:

- **`_legacy/v1`** (dashboard Google Apps Script): consolidação, ghost mode e
  manifest PWA confirmados como já absorvidos no runtime atual; score/perfil
  gamificado e recomendação tática de compra/venda descartados (fora de
  escopo do produto); concentração por ativo e alertas de risco marcados como
  **pendentes** (ausentes na raiz, sem feature nova criada).
- **`_legacy/vera-insights`** (motor Vera standalone): cascata de 4
  provedores de IA, behavioral tracking e narrativas por regras descartados
  (específicos do produto Vera descontinuado); persistência de snapshots,
  cache com TTL e clientes de mercado próprios substituídos pelos
  equivalentes canônicos da raiz; motor determinístico de metas (PMT) e
  concentração via Herfindahl marcados como **pendentes** — mesma lacuna já
  identificada no PR #168 e não decidida sozinha nesta sessão.

Reconfirma por grep que `apresentacao/src`, `servidores` e `bibliotecas` não
importam nada de `_legacy`.

## Decisão explicitamente não tomada

O domínio `decisoes/vera` ativo no backend **não foi tocado nem marcado como
legado** — só o produto Vera foi descontinuado (decisão do Luiz, registrada
no fechamento de #114). O que fazer com esse domínio de código continua
decisão do Luiz, fora do escopo mecânico desta issue.

## Fora de escopo (não feito nesta sessão)

`_legacy/v2`, `_legacy/bridge` e `_legacy/quanto` ainda não foram
inventariados item a item — `_legacy/quanto` já tem síntese em nível de
matriz nas seções 3-6 do documento, mas falta o detalhamento com ponteiro
para código/issue que o critério de aceite de #115 exige. `_legacy` **não
foi congelado** ainda — isso só deve acontecer depois que os três legados
restantes forem cobertos.

## Testes

- `npm run typecheck` — 0 erros.
- `npm run test:api` — 36/36.

Refs #115 — issue não fecha por esta PR (cobre 2 de 5 legados; ver seção 11.5 do documento para o que falta).