### PR TITLE
fix: compatibilizar configuração com Codex CLI

### DIFF
--- a/.codex/agents/augusto.toml
+++ b/.codex/agents/augusto.toml
@@ -1,7 +1,5 @@
 name = "Augusto"
 description = "Augusto revisa mudanças do Esquilo Wallet antes da abertura ou aprovação de um PR."
-model = "gpt-5.6"
-model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 
 developer_instructions = """

--- a/.codex/agents/davi.toml
+++ b/.codex/agents/davi.toml
@@ -1,7 +1,5 @@
 name = "Davi"
 description = "Davi explora o Esquilo Wallet em modo somente leitura antes de uma implementação."
-model = "gpt-5.6-terra"
-model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 
 developer_instructions = """

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,11 +1,2 @@
-model = "gpt-5.6"
-model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 approval_policy = "on-request"
-
-[agents]
-enabled = true
-max_concurrent_threads_per_session = 3
-default_subagent_model = "gpt-5.6-terra"
-default_subagent_reasoning_effort = "medium"
-interrupt_message = true


### PR DESCRIPTION
## Problema

O Codex CLI 0.144.6 autenticado com ChatGPT rejeita a configuração atual:

- o bloco `[agents]` é interpretado como mapa de papéis e não aceita valores booleanos;
- os modelos `gpt-5.6` e `gpt-5.6-terra` fixados pelo projeto não são suportados nessa autenticação.

Isso impede iniciar o Codex no repositório e também impede executar Davi e Augusto.

## Solução

- remove o bloco global incompatível de `.codex/config.toml`;
- remove modelo e esforço fixados no projeto;
- mantém sandbox e aprovação sob demanda;
- faz Davi e Augusto herdarem o modelo suportado pela sessão principal;
- preserva ambos em modo somente leitura.

## Validação

- alteração limitada aos três arquivos de configuração do Codex;
- nenhuma instrução ou função dos agentes foi removida;
- nenhum código de produto foi alterado.

## Risco residual

A escolha concreta do modelo passa a ser responsabilidade do Codex CLI e da conta autenticada, evitando identificadores incompatíveis persistidos no repositório.
