### PR TITLE
feat(android): modulariza fronteiras Savro

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -112,7 +112,7 @@ tasks.register("verifyArchitecture") {
 
         pureModulePaths.forEach { modulePath ->
             val project = project(modulePath)
-            val kotlinSources = project.fileTree("src") {
+            val kotlinSources = project.fileTree("src/main") {
                 include("**/*.kt")
             }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,139 @@
+import org.gradle.api.artifacts.ProjectDependency
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+}
+
+private val pureModulePaths = setOf(
+    ":core:common",
+    ":core:model",
+    ":core:testing",
+    ":domain:patrimonio",
+)
+
+private val allowedProductionDependencies = mapOf(
+    ":app" to emptySet<String>(),
+    ":core:common" to emptySet<String>(),
+    ":core:model" to emptySet<String>(),
+    ":core:testing" to emptySet<String>(),
+    ":domain:patrimonio" to setOf(":core:common", ":core:model"),
+)
+
+private val forbiddenPureSourceReferences = listOf(
+    "android.",
+    "androidx.compose.",
+    "androidx.room.",
+    "androidx.sqlite.",
+    "net.sqlcipher.",
+    "java.sql.",
+    "kotlinx.serialization.",
+    "okhttp.",
+    "retrofit2.",
+    "io.ktor.client.",
+)
+
+private val forbiddenPureDependencyGroups = listOf(
+    "androidx.",
+    "com.android.",
+    "net.sqlcipher",
+    "org.xerial",
+    "com.squareup.",
+    "io.ktor",
+    "org.jetbrains.kotlinx:kotlinx-serialization",
+)
+
+tasks.register("verifyArchitecture") {
+    group = "verification"
+    description = "Verifica o grafo Gradle e as fronteiras dos módulos Android puros."
+
+    doLast {
+        val violations = mutableListOf<String>()
+
+        rootProject.subprojects.forEach { project ->
+            val isFeature = project.path.startsWith(":feature:")
+            val projectDependenciesByConfiguration = project.configurations
+                .filter { it.isCanBeResolved || it.isCanBeDeclared }
+                .associate { configuration ->
+                    configuration.name to configuration.dependencies
+                        .withType(ProjectDependency::class.java)
+                        .map { it.path }
+                        .toSet()
+                }
+
+            projectDependenciesByConfiguration.forEach { (configuration, dependencies) ->
+                val isTestConfiguration = configuration.contains("test", ignoreCase = true)
+
+                if (!isTestConfiguration && ":core:testing" in dependencies) {
+                    violations += "${project.path}:$configuration não pode colocar :core:testing no runtime de produção"
+                }
+
+                if (project.path == ":core:testing" && !isTestConfiguration && dependencies.isNotEmpty()) {
+                    violations += ":core:testing só pode declarar dependências de projeto em configurações de teste; " +
+                        "encontrada em $configuration: ${dependencies.sorted()}"
+                }
+
+                if (!isTestConfiguration) {
+                    val allowed = allowedProductionDependencies[project.path]
+                    if (allowed != null) {
+                        val unexpected = dependencies - allowed
+                        if (unexpected.isNotEmpty()) {
+                            violations += "${project.path}:$configuration depende de ${unexpected.sorted()}, fora da allowlist ${allowed.sorted()}"
+                        }
+                    }
+
+                    if (project.path in pureModulePaths) {
+                        val forbiddenExternalDependencies = project.configurations
+                            .getByName(configuration)
+                            .dependencies
+                            .filter { dependency ->
+                                val coordinate = listOfNotNull(dependency.group, dependency.name).joinToString(":")
+                                forbiddenPureDependencyGroups.any { coordinate.startsWith(it) }
+                            }
+                            .map { dependency -> "${dependency.group}:${dependency.name}" }
+                        if (forbiddenExternalDependencies.isNotEmpty()) {
+                            violations += "${project.path}:$configuration declara dependências proibidas ${forbiddenExternalDependencies.sorted()}"
+                        }
+                    }
+                }
+
+                if (isFeature) {
+                    val forbiddenFeatureDependencies = dependencies.filter {
+                        it.startsWith(":feature:") || it == ":core:database" || it == ":core:network"
+                    }
+                    if (forbiddenFeatureDependencies.isNotEmpty()) {
+                        violations += "${project.path}:$configuration não pode depender de ${forbiddenFeatureDependencies.sorted()}"
+                    }
+                }
+            }
+        }
+
+        pureModulePaths.forEach { modulePath ->
+            val project = project(modulePath)
+            val kotlinSources = project.fileTree("src") {
+                include("**/*.kt")
+            }
+
+            kotlinSources.forEach { source ->
+                val content = source.readText()
+                forbiddenPureSourceReferences.forEach { forbiddenReference ->
+                    if (content.contains(forbiddenReference)) {
+                        violations += "$modulePath contém referência proibida '$forbiddenReference' em ${source.relativeTo(project.projectDir)}"
+                    }
+                }
+            }
+        }
+
+        check(violations.isEmpty()) {
+            "Fronteiras arquiteturais violadas:\n${violations.joinToString("\n") { "- $it" }}"
+        }
+    }
+}
+
+tasks.register("check") {
+    group = "verification"
+    description = "Executa as verificações arquiteturais do projeto Android."
+    dependsOn(tasks.named("verifyArchitecture"))
 }

--- a/android/core/common/build.gradle.kts
+++ b/android/core/common/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}

--- a/android/core/model/build.gradle.kts
+++ b/android/core/model/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}

--- a/android/core/testing/build.gradle.kts
+++ b/android/core/testing/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+// Este módulo é suporte de teste. Nenhum módulo de produção pode declará-lo em api/implementation.

--- a/android/core/testing/build.gradle.kts
+++ b/android/core/testing/build.gradle.kts
@@ -1,5 +1,15 @@
+import org.gradle.api.tasks.testing.Test
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-// Este módulo é suporte de teste. Nenhum módulo de produção pode declará-lo em api/implementation.
+dependencies {
+    testImplementation(gradleTestKit())
+    testImplementation(libs.junit)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnit()
+    systemProperty("savro.android.root", rootProject.projectDir.absolutePath)
+}

--- a/android/core/testing/src/test/kotlin/io/savro/testing/VerifyArchitectureFunctionalTest.kt
+++ b/android/core/testing/src/test/kotlin/io/savro/testing/VerifyArchitectureFunctionalTest.kt
@@ -1,0 +1,104 @@
+package io.savro.testing
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
+
+class VerifyArchitectureFunctionalTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun approvesTheCurrentAllowedGraph() {
+        val fixture = copyAndroidProject()
+
+        val result = runVerifier(fixture).build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":verifyArchitecture")?.outcome)
+    }
+
+    @Test
+    fun rejectsForbiddenDomainDependency() {
+        val fixture = copyAndroidProject()
+        appendTo(fixture.resolve("domain/patrimonio/build.gradle.kts"), """
+
+            dependencies {
+                implementation(project(\":app\"))
+            }
+        """.trimIndent())
+
+        val result = runVerifier(fixture).buildAndFail()
+
+        assertTrue(result.output.contains(":domain:patrimonio"))
+    }
+
+    @Test
+    fun rejectsTestingModuleInProductionConfiguration() {
+        val fixture = copyAndroidProject()
+        appendTo(fixture.resolve("core/model/build.gradle.kts"), """
+
+            dependencies {
+                implementation(project(\":core:testing\"))
+            }
+        """.trimIndent())
+
+        val result = runVerifier(fixture).buildAndFail()
+
+        assertTrue(result.output.contains(":core:testing"))
+    }
+
+    @Test
+    fun rejectsForbiddenReferenceInPureSource() {
+        val fixture = copyAndroidProject()
+        val source = fixture.resolve("core/common/src/main/kotlin/io/savro/common/ReferênciaProibida.kt")
+        Files.createDirectories(source.parent)
+        Files.writeString(source, "import android.content.Context\n")
+
+        val result = runVerifier(fixture).buildAndFail()
+
+        assertTrue(result.output.contains("android."))
+    }
+
+    private fun copyAndroidProject(): Path {
+        val destination = temporaryFolder.newFolder("fixture").toPath()
+        val source = Path.of(requireNotNull(System.getProperty("savro.android.root")))
+
+        Files.walkFileTree(source, object : SimpleFileVisitor<Path>() {
+            override fun preVisitDirectory(directory: Path, attributes: BasicFileAttributes): FileVisitResult {
+                val relative = source.relativize(directory)
+                if (relative.any { it.toString() == ".gradle" || it.toString() == "build" }) {
+                    return FileVisitResult.SKIP_SUBTREE
+                }
+                Files.createDirectories(destination.resolve(relative))
+                return FileVisitResult.CONTINUE
+            }
+
+            override fun visitFile(file: Path, attributes: BasicFileAttributes): FileVisitResult {
+                val relative = source.relativize(file)
+                Files.copy(file, destination.resolve(relative), StandardCopyOption.COPY_ATTRIBUTES)
+                return FileVisitResult.CONTINUE
+            }
+        })
+
+        return destination
+    }
+
+    private fun runVerifier(projectDirectory: Path): GradleRunner = GradleRunner.create()
+        .withProjectDir(projectDirectory.toFile())
+        .withArguments("--stacktrace", "verifyArchitecture")
+
+    private fun appendTo(file: Path, content: String) {
+        Files.writeString(file, "${System.lineSeparator()}$content${System.lineSeparator()}")
+    }
+}

--- a/android/domain/patrimonio/build.gradle.kts
+++ b/android/domain/patrimonio/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+    implementation(project(":core:common"))
+    implementation(project(":core:model"))
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -22,3 +22,4 @@ androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", vers
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -16,3 +16,7 @@ dependencyResolutionManagement {
 
 rootProject.name = "savro-android"
 include(":app")
+include(":core:common")
+include(":core:model")
+include(":core:testing")
+include(":domain:patrimonio")

--- a/documentacao/arquitetura/validacoes/117-C-contratos-de-fronteira.md
+++ b/documentacao/arquitetura/validacoes/117-C-contratos-de-fronteira.md
@@ -15,11 +15,13 @@
 
 `domain:patrimonio` depende somente de `core:common` e `core:model`. Os três módulos `core` e o módulo de domínio usam Kotlin/JVM, sem Android, Compose, Room, SQLCipher, SQLite, KSP, HTTP, JSON, DTOs de rede ou DI. `core:testing` não é dependência de produção e a regra arquitetural reprova seu uso em configurações que não sejam de teste.
 
+Os módulos `core:common`, `core:model` e `domain:patrimonio` são, nesta entrega, **estrutura arquitetural sem fontes de produção e sem entrega funcional**. O módulo `core:testing` contém apenas a cobertura funcional do verificador arquitetural. Isso é deliberado: a issue não aprova comportamento de patrimônio, e preencher módulos com marcadores, interfaces vazias ou regras especulativas seria desvio de escopo.
+
 ## Contratos de domínio deliberadamente adiados
 
 A ADR-001 estabelece que o domínio não conhece detalhes de UI, banco ou rede e que persistência futura deve ficar atrás de sua fronteira. Contudo, #178 não especifica nenhuma operação patrimonial: CRUD, movimentos, importação, saldo, resumo, histórico, cálculo e rede pública pertencem a outras issues.
 
-Por isso, esta task não cria interfaces vazias nem métodos especulativos. Portas com operações concretas serão criadas apenas quando uma issue aprovada definir a semântica:
+Por isso, esta task não cria interfaces vazias nem métodos especulativos. A fronteira entregue é a estrutura de módulos e as regras executáveis. Portas com operações concretas serão criadas apenas quando uma issue aprovada definir a semântica:
 
 | Porta futura | Origem necessária |
 |---|---|
@@ -35,5 +37,13 @@ Por isso, esta task não cria interfaces vazias nem métodos especulativos. Port
 2. proibição de `core:testing` fora de configurações de teste;
 3. proibição preventiva de feature para feature, `core:database` e `core:network`;
 4. inspeção de fontes Kotlin dos módulos puros para referências a APIs proibidas.
+
+`core:testing` executa quatro fixtures Gradle TestKit contra uma cópia temporária do projeto Android: grafo válido, dependência proibida no domínio, uso de `core:testing` em produção e referência proibida em fonte pura. Os três cenários inválidos usam `buildAndFail()`, comprovando que a regra efetivamente interrompe o build.
+
+## Evidência de validação
+
+Nesta etapa estrutural, os seguintes módulos não possuem fontes de produção nem testes de domínio: `core:common`, `core:model` e `domain:patrimonio`. No Gradle, suas tarefas `compileKotlin`, `compileJava` e `test` terminam como `NO-SOURCE`; isso confirma ausência intencional de entrega funcional, não uma suíte aprovada.
+
+`core:testing` também possui `compileKotlin` como `NO-SOURCE`, pois não entra no runtime. Diferentemente dos demais, `compileTestKotlin` e `test` executam código: a suíte `VerifyArchitectureFunctionalTest` roda as quatro fixtures TestKit descritas acima. Além dessa suíte, `verifyArchitecture` executa a regra Gradle no projeto real e `:app:assembleDevDebug` compila/empacota o bootstrap já existente.
 
 A inspeção de fontes é uma defesa complementar. A barreira principal é o grafo Gradle: módulos puros não recebem plugin Android nem dependências que disponibilizem classes Android, banco, SQLCipher ou HTTP no classpath de produção.

--- a/documentacao/arquitetura/validacoes/117-C-contratos-de-fronteira.md
+++ b/documentacao/arquitetura/validacoes/117-C-contratos-de-fronteira.md
@@ -1,0 +1,39 @@
+# 117-C — modularização e contratos de fronteira
+
+- **Issue:** #178 (filha de #117)
+- **Escopo:** módulos Gradle puros, allowlist arquitetural e fronteiras de dependência.
+
+## Módulos entregues
+
+```text
+:app
+:core:common
+:core:model
+:core:testing
+:domain:patrimonio
+```
+
+`domain:patrimonio` depende somente de `core:common` e `core:model`. Os três módulos `core` e o módulo de domínio usam Kotlin/JVM, sem Android, Compose, Room, SQLCipher, SQLite, KSP, HTTP, JSON, DTOs de rede ou DI. `core:testing` não é dependência de produção e a regra arquitetural reprova seu uso em configurações que não sejam de teste.
+
+## Contratos de domínio deliberadamente adiados
+
+A ADR-001 estabelece que o domínio não conhece detalhes de UI, banco ou rede e que persistência futura deve ficar atrás de sua fronteira. Contudo, #178 não especifica nenhuma operação patrimonial: CRUD, movimentos, importação, saldo, resumo, histórico, cálculo e rede pública pertencem a outras issues.
+
+Por isso, esta task não cria interfaces vazias nem métodos especulativos. Portas com operações concretas serão criadas apenas quando uma issue aprovada definir a semântica:
+
+| Porta futura | Origem necessária |
+|---|---|
+| Persistência patrimonial local e transacional | #119 e #180 |
+| Regras/casos de uso patrimoniais | #179 e #119 |
+| Cotação, catálogo, manifesto ou pacote público | #182 |
+
+## Regra executável
+
+`verifyArchitecture`, ligado a `check`, combina:
+
+1. inspeção das dependências de projeto declaradas no Gradle contra uma allowlist;
+2. proibição de `core:testing` fora de configurações de teste;
+3. proibição preventiva de feature para feature, `core:database` e `core:network`;
+4. inspeção de fontes Kotlin dos módulos puros para referências a APIs proibidas.
+
+A inspeção de fontes é uma defesa complementar. A barreira principal é o grafo Gradle: módulos puros não recebem plugin Android nem dependências que disponibilizem classes Android, banco, SQLCipher ou HTTP no classpath de produção.


### PR DESCRIPTION
## Problema
O bootstrap Android possuía apenas `:app`, sem módulos puros nem regra executável que impedisse violações de fronteira.

## Solução
- cria `:core:common`, `:core:model`, `:core:testing` e `:domain:patrimonio`;
- mantém `:app` sem dependência artificial;
- limita `:domain:patrimonio` a `:core:common` e `:core:model`;
- adiciona `verifyArchitecture` ligado a `check`, combinando allowlist do grafo Gradle, bloqueio de `:core:testing` em runtime, regras preventivas para features, coordenadas externas proibidas e inspeção complementar de `src/main` dos módulos puros;
- adiciona quatro fixtures Gradle TestKit que executam o `verifyArchitecture` real em cópias temporárias do projeto;
- registra na #178 e na documentação que esta é uma entrega estrutural, sem comportamento patrimonial ou portas especulativas.

## Cobertura real
`VerifyArchitectureFunctionalTest` executou código e verificou:

- grafo permitido aprovado;
- `:domain:patrimonio → :app` rejeitado;
- `:core:testing` em `implementation` rejeitado;
- import Android em fonte pura de produção rejeitado.

Os três casos inválidos usam `buildAndFail()` contra o build copiado; não repetem a lógica do verificador em teste.

## Estado das tarefas JVM
- `:core:common`, `:core:model` e `:domain:patrimonio`: `compileKotlin`, `compileJava` e `test` ficaram `NO-SOURCE`. São módulos estruturais sem fontes e sem entrega funcional nesta issue.
- `:core:testing`: `compileKotlin` ficou `NO-SOURCE` por não participar do runtime; `compileTestKotlin` e `test` executaram a suíte TestKit real.
- `verifyArchitecture` executou a regra Gradle no projeto real.
- `:app:assembleDevDebug` compilou/empacotou o bootstrap existente.

## Escopo preservado
Não altera `apresentacao/android/**`, UI, navegação, banco, rede, SQLCipher, Room, CI ou design system. Interfaces vazias, CRUD especulativo e portas de rede permanecem proibidos; operações concretas aguardam #179, #119, #180 e #182, conforme registrado na #178.

## Validações
- `./gradlew check`
- `./gradlew verifyArchitecture`
- `./gradlew :core:testing:test` (quatro testes TestKit)
- `./gradlew :app:assembleDevDebug`
- `git diff --check`
- revisão completa do Augusto

Closes #178