### PR TITLE
feat(aplicativo): cadastro manual e manutencao de itens patrimoniais (#119)

### DIFF
--- a/aplicativo/androidApp/src/main/kotlin/io/savro/app/MainActivity.kt
+++ b/aplicativo/androidApp/src/main/kotlin/io/savro/app/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : FragmentActivity() {
         val composicao = ComposicaoCofreAndroid(this).also { composicaoCofre = it }
 
         setContent {
-            SavroApp(gerenciador = composicao.gerenciadorCofre)
+            SavroApp(gerenciador = composicao.gerenciadorCofre, servicoPatrimonio = composicao.servicoPatrimonio)
         }
     }
 

--- a/aplicativo/build.gradle.kts
+++ b/aplicativo/build.gradle.kts
@@ -40,6 +40,8 @@ private val allowedProductionDependencies = mapOf(
         ":shared:core:security",
         ":shared:domain:patrimonio",
     ),
+    // (nota: ":shared:core:model" já estava na allowlist acima antes desta issue — só a
+    // declaração em shared/app/build.gradle.kts estava faltando; ver #119)
     ":shared:core:common" to emptySet<String>(),
     ":shared:core:model" to emptySet<String>(),
     // :core:testing hospeda fakes/fixtures reutilizáveis (RepositorioItensPatrimoniaisContratoTeste

--- a/aplicativo/iosApp/iosApp/iOSApp.swift
+++ b/aplicativo/iosApp/iosApp/iOSApp.swift
@@ -8,6 +8,13 @@ struct iOSApp: App {
 
     var body: some Scene {
         WindowGroup {
+            // `ContentView()` precisa manter a mesma posição estrutural na `ZStack` em qualquer
+            // `scenePhase` — é isso que garante que o SwiftUI nunca invalide a identidade da
+            // `ComposeView` (`ContentView.swift`) e, com isso, nunca recrie o `UIViewController`
+            // do Compose. Envolver `ContentView()` num `if`/`AnyView` condicional aqui quebraria a
+            // preservação de `rememberSaveable` entre background e foreground (#119, ver
+            // `SavroAppViewController()` em `SavroViewController.kt`) mesmo sem tocar em nenhum
+            // código Kotlin.
             ZStack {
                 ContentView()
                 if scenePhase != .active {

--- a/aplicativo/shared/app/build.gradle.kts
+++ b/aplicativo/shared/app/build.gradle.kts
@@ -31,7 +31,10 @@ kotlin {
             // BiometricPrompt, notificar background/foreground) — inevitável porque `BiometricPrompt`
             // exige uma referência de Activity viva, diferente do Keychain/LAContext do iOS.
             api(project(":shared:core:security"))
-            implementation(project(":shared:domain:patrimonio"))
+            // api (não implementation): :androidApp precisa enxergar `ServicoPatrimonio` a partir
+            // de `ComposicaoCofreAndroid.servicoPatrimonio` (#119), mesmo motivo do
+            // shared:core:security acima.
+            api(project(":shared:domain:patrimonio"))
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
             implementation(libs.compose.components.resources)

--- a/aplicativo/shared/app/build.gradle.kts
+++ b/aplicativo/shared/app/build.gradle.kts
@@ -21,6 +21,10 @@ kotlin {
         commonMain.dependencies {
             api(project(":shared:core:designsystem"))
             implementation(project(":shared:core:common"))
+            // implementation (não api): a tela de patrimônio (#119) usa ItemPatrimonial/
+            // TipoItemPatrimonial diretamente — antes só chegava transitivamente via
+            // shared:domain:patrimonio, que expõe como `implementation`, não `api`.
+            implementation(project(":shared:core:model"))
             implementation(project(":shared:core:database"))
             // api (não implementation): :androidApp precisa enxergar `GerenciadorCofre` e
             // `AutenticadorBiometricoAndroid` para o wiring de ciclo de vida (vincular Activity ao

--- a/aplicativo/shared/app/src/androidMain/kotlin/io/savro/app/ComposicaoCofreAndroid.kt
+++ b/aplicativo/shared/app/src/androidMain/kotlin/io/savro/app/ComposicaoCofreAndroid.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.FragmentActivity
 import io.savro.database.ProvedorChaveMestraAndroid
 import io.savro.database.RelogioDoSistemaAndroid
 import io.savro.database.RepositorioItensPatrimoniaisRoom
+import io.savro.domain.patrimonio.ServicoPatrimonio
 import io.savro.security.AutenticadorBiometricoAndroid
 import io.savro.security.GerenciadorCofre
 import io.savro.security.PreferenciasCofreAndroid
@@ -30,19 +31,20 @@ class ComposicaoCofreAndroid(activity: FragmentActivity) {
 
     val autenticador = AutenticadorBiometricoAndroid(context)
 
-    val gerenciadorCofre: GerenciadorCofre = run {
-        val provedorChaveMestra = ProvedorChaveMestraAndroid(context)
-        val repositorio = RepositorioItensPatrimoniaisRoom(context, provedorChaveMestra)
-        val preferencias = PreferenciasCofreAndroid(context)
-        GerenciadorCofre(
-            provedorChaveMestra = provedorChaveMestra,
-            repositorio = repositorio,
-            autenticador = autenticador,
-            preferencias = preferencias,
-            relogio = RelogioDoSistemaAndroid,
-            escopo = escopo,
-        )
-    }
+    private val provedorChaveMestra = ProvedorChaveMestraAndroid(context)
+    private val repositorio = RepositorioItensPatrimoniaisRoom(context, provedorChaveMestra)
+
+    val gerenciadorCofre: GerenciadorCofre = GerenciadorCofre(
+        provedorChaveMestra = provedorChaveMestra,
+        repositorio = repositorio,
+        autenticador = autenticador,
+        preferencias = PreferenciasCofreAndroid(context),
+        relogio = RelogioDoSistemaAndroid,
+        escopo = escopo,
+    )
+
+    /** Cadastro manual de patrimônio (issue #119) — mesma conexão de banco do [gerenciadorCofre]. */
+    val servicoPatrimonio = ServicoPatrimonio(repositorio, RelogioDoSistemaAndroid)
 
     init {
         autenticador.vincularAtividade(activity)

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreScreens.kt
@@ -39,9 +39,6 @@ import io.savro.app.recursos.configuracao_protecao_estado_ativada
 import io.savro.app.recursos.configuracao_protecao_estado_desativada
 import io.savro.app.recursos.configuracao_protecao_permitir_credencial
 import io.savro.app.recursos.configuracao_protecao_titulo
-import io.savro.app.recursos.home_botao_protecao
-import io.savro.app.recursos.home_subtitulo
-import io.savro.app.recursos.home_titulo
 import io.savro.designsystem.componentes.SavroButton
 import io.savro.designsystem.componentes.SavroButtonStyle
 import io.savro.designsystem.componentes.SavroFilterChip
@@ -50,6 +47,7 @@ import io.savro.designsystem.componentes.SavroStatePanel
 import io.savro.designsystem.componentes.SavroText
 import io.savro.designsystem.componentes.SavroTextStyle
 import io.savro.designsystem.tema.SavroThemeTokens
+import io.savro.domain.patrimonio.ServicoPatrimonio
 import io.savro.security.EstadoCofre
 import io.savro.security.GerenciadorCofre
 import io.savro.security.PoliticaProtecao
@@ -58,7 +56,7 @@ import org.jetbrains.compose.resources.stringResource
 
 /** Despacha a UI a partir do [EstadoCofre] atual — os 8 estados obrigatórios da #118. */
 @Composable
-internal fun TelaCofre(gerenciador: GerenciadorCofre) {
+internal fun TelaCofre(gerenciador: GerenciadorCofre, servicoPatrimonio: ServicoPatrimonio) {
     val estado by gerenciador.estado.collectAsState()
     val escopo = rememberCoroutineScope()
 
@@ -69,7 +67,7 @@ internal fun TelaCofre(gerenciador: GerenciadorCofre) {
             message = stringResource(Res.string.cofre_descriptografando_mensagem),
         )
 
-        EstadoCofre.Desbloqueado -> TelaHome(gerenciador)
+        EstadoCofre.Desbloqueado -> TelaHome(gerenciador, servicoPatrimonio)
 
         is EstadoCofre.CredencialInvalida -> SavroStatePanel(
             state = SavroState.Error,
@@ -143,12 +141,13 @@ private fun BotaoTentarNovamente(gerenciador: GerenciadorCofre) {
 }
 
 /**
- * Destino mínimo pós-onboarding/desbloqueio (#118 não implementa telas patrimoniais — isso é
- * #119/#120). Único ponto funcional além do placeholder: acesso a ativar/alterar/remover a
- * proteção, exigido pelos critérios de aceite.
+ * Destino pós-onboarding/desbloqueio: cadastro manual de patrimônio (#119) é a experiência
+ * principal do app hoje — Home/Patrimônio definitivas com gráficos e resumo consolidado são a
+ * #120, fora do escopo aqui. Acesso a ativar/alterar/remover a proteção do cofre (#118) continua
+ * disponível a partir daqui.
  */
 @Composable
-private fun TelaHome(gerenciador: GerenciadorCofre) {
+private fun TelaHome(gerenciador: GerenciadorCofre, servicoPatrimonio: ServicoPatrimonio) {
     var mostrarConfiguracaoProtecao by remember { mutableStateOf(false) }
 
     if (mostrarConfiguracaoProtecao) {
@@ -156,20 +155,10 @@ private fun TelaHome(gerenciador: GerenciadorCofre) {
         return
     }
 
-    Column(
-        modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md),
-        verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.lg),
-    ) {
-        SavroText(stringResource(Res.string.home_titulo), style = SavroTextStyle.Headline)
-        SavroText(stringResource(Res.string.home_subtitulo), style = SavroTextStyle.Body)
-        SavroButton(
-            label = stringResource(Res.string.home_botao_protecao),
-            onClick = { mostrarConfiguracaoProtecao = true },
-            style = SavroButtonStyle.Secondary,
-            loadingStateDescription = "",
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
+    TelaPatrimonio(
+        servico = servicoPatrimonio,
+        aoAbrirConfiguracaoProtecao = { mostrarConfiguracaoProtecao = true },
+    )
 }
 
 /** Permite ativar, alterar e remover a proteção do cofre (#118, critério de aceite obrigatório). */

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/PatrimonioScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/PatrimonioScreens.kt
@@ -1,0 +1,487 @@
+package io.savro.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import io.savro.common.Resultado
+import io.savro.designsystem.componentes.SavroButton
+import io.savro.designsystem.componentes.SavroButtonStyle
+import io.savro.designsystem.componentes.SavroCard
+import io.savro.designsystem.componentes.SavroDivider
+import io.savro.designsystem.componentes.SavroFilterChip
+import io.savro.designsystem.componentes.SavroState
+import io.savro.designsystem.componentes.SavroStatePanel
+import io.savro.designsystem.componentes.SavroText
+import io.savro.designsystem.componentes.SavroTextField
+import io.savro.designsystem.componentes.SavroTextStyle
+import io.savro.designsystem.tema.SavroThemeTokens
+import io.savro.domain.patrimonio.CampoFormularioItem
+import io.savro.domain.patrimonio.ConversorMonetario
+import io.savro.domain.patrimonio.ErroServicoPatrimonio
+import io.savro.domain.patrimonio.ErroValidacaoItem
+import io.savro.domain.patrimonio.EstadoFormularioItemPatrimonial
+import io.savro.domain.patrimonio.FiltroItensPatrimoniais
+import io.savro.domain.patrimonio.RascunhoFormularioItem
+import io.savro.domain.patrimonio.ResumoItemPatrimonial
+import io.savro.domain.patrimonio.ServicoPatrimonio
+import io.savro.domain.patrimonio.ValidadorItemPatrimonial
+import io.savro.model.ItemPatrimonial
+import io.savro.model.TipoItemPatrimonial
+import kotlinx.coroutines.launch
+
+/**
+ * Cadastro manual de patrimônio (issue #119). Navegação local (sem biblioteca externa — a #120 é
+ * quem introduz navegação real entre Home/Patrimônio/Detalhe): lista com busca/filtro é o destino
+ * padrão; formulário e ajuste de valor são sobrepostos por cima quando abertos.
+ */
+private sealed class DestinoPatrimonio {
+    data object Lista : DestinoPatrimonio()
+    data class Formulario(val itemIdEmEdicao: String?) : DestinoPatrimonio()
+    data class Ajuste(val itemId: String) : DestinoPatrimonio()
+}
+
+@Composable
+internal fun TelaPatrimonio(servico: ServicoPatrimonio, aoAbrirConfiguracaoProtecao: () -> Unit) {
+    var destino by remember { mutableStateOf<DestinoPatrimonio>(DestinoPatrimonio.Lista) }
+
+    LaunchedEffect(servico) { servico.carregar() }
+
+    when (val atual = destino) {
+        DestinoPatrimonio.Lista -> TelaListaPatrimonio(
+            servico = servico,
+            aoAbrirConfiguracaoProtecao = aoAbrirConfiguracaoProtecao,
+            aoCriar = { destino = DestinoPatrimonio.Formulario(itemIdEmEdicao = null) },
+            aoEditar = { id -> destino = DestinoPatrimonio.Formulario(itemIdEmEdicao = id) },
+            aoAjustarValor = { id -> destino = DestinoPatrimonio.Ajuste(id) },
+        )
+        is DestinoPatrimonio.Formulario -> TelaFormularioItem(
+            servico = servico,
+            itemIdEmEdicao = atual.itemIdEmEdicao,
+            aoSalvar = { destino = DestinoPatrimonio.Lista },
+            aoCancelar = { destino = DestinoPatrimonio.Lista },
+        )
+        is DestinoPatrimonio.Ajuste -> TelaAjusteDeValor(
+            servico = servico,
+            itemId = atual.itemId,
+            aoConcluir = { destino = DestinoPatrimonio.Lista },
+        )
+    }
+}
+
+@Composable
+private fun TelaListaPatrimonio(
+    servico: ServicoPatrimonio,
+    aoAbrirConfiguracaoProtecao: () -> Unit,
+    aoCriar: () -> Unit,
+    aoEditar: (String) -> Unit,
+    aoAjustarValor: (String) -> Unit,
+) {
+    val itens by servico.itens.collectAsState()
+    var texto by remember { mutableStateOf("") }
+    var tipoSelecionado by remember { mutableStateOf<TipoItemPatrimonial?>(null) }
+    var mostrarArquivados by remember { mutableStateOf(false) }
+    val escopo = rememberCoroutineScope()
+
+    val filtro = FiltroItensPatrimoniais(
+        texto = texto,
+        tipos = tipoSelecionado?.let { setOf(it) } ?: emptySet(),
+        incluirArquivados = mostrarArquivados,
+    )
+    val itensFiltrados = filtro.aplicar(itens)
+
+    Column(modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            SavroText("Patrimônio", style = SavroTextStyle.Headline)
+            SavroButton(
+                label = "Proteção",
+                onClick = aoAbrirConfiguracaoProtecao,
+                style = SavroButtonStyle.Secondary,
+                loadingStateDescription = "",
+            )
+        }
+
+        SavroButton(
+            label = "Novo item",
+            onClick = aoCriar,
+            modifier = Modifier.fillMaxWidth().padding(top = SavroThemeTokens.spacing.sm),
+            loadingStateDescription = "",
+        )
+
+        SavroTextField(
+            value = texto,
+            onValueChange = { texto = it },
+            label = "Buscar",
+            modifier = Modifier.fillMaxWidth().padding(top = SavroThemeTokens.spacing.md),
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = SavroThemeTokens.spacing.sm),
+            horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm),
+        ) {
+            SavroFilterChip(
+                label = "Arquivados",
+                selected = mostrarArquivados,
+                onClick = { mostrarArquivados = !mostrarArquivados },
+            )
+            TipoItemPatrimonial.entries.forEach { tipo ->
+                SavroFilterChip(
+                    label = rotuloDoTipo(tipo),
+                    selected = tipoSelecionado == tipo,
+                    onClick = { tipoSelecionado = if (tipoSelecionado == tipo) null else tipo },
+                )
+            }
+        }
+
+        if (itensFiltrados.isEmpty()) {
+            SavroStatePanel(
+                state = SavroState.Empty,
+                title = "Nenhum item encontrado",
+                message = "Cadastre um item ou ajuste a busca/filtro.",
+                modifier = Modifier.padding(top = SavroThemeTokens.spacing.md),
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(top = SavroThemeTokens.spacing.md),
+                verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm),
+            ) {
+                items(itensFiltrados, key = { it.id }) { item ->
+                    ItemPatrimonialCard(
+                        item = item,
+                        aoEditar = { aoEditar(item.id) },
+                        aoAjustarValor = { aoAjustarValor(item.id) },
+                        aoDuplicar = { escopo.launch { servico.duplicar(item.id) } },
+                        aoArquivar = { escopo.launch { servico.arquivar(item.id, arquivado = !item.arquivado) } },
+                        aoExcluir = { escopo.launch { servico.excluir(item.id) } },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ItemPatrimonialCard(
+    item: ItemPatrimonial,
+    aoEditar: () -> Unit,
+    aoAjustarValor: () -> Unit,
+    aoDuplicar: () -> Unit,
+    aoArquivar: () -> Unit,
+    aoExcluir: () -> Unit,
+) {
+    SavroCard(modifier = Modifier.fillMaxWidth()) {
+        SavroText(item.nome, style = SavroTextStyle.Title)
+        SavroText("${rotuloDoTipo(item.tipo)} · ${formatarValor(item)} ${item.moeda}", style = SavroTextStyle.Body)
+        item.instituicao?.let { SavroText(it, style = SavroTextStyle.BodySmall) }
+        if (item.arquivado) SavroText("Arquivado", style = SavroTextStyle.Label)
+
+        SavroDivider(modifier = Modifier.padding(vertical = SavroThemeTokens.spacing.sm))
+
+        Row(horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+            SavroButton(label = "Editar", onClick = aoEditar, style = SavroButtonStyle.Secondary, loadingStateDescription = "")
+            SavroButton(label = "Ajustar valor", onClick = aoAjustarValor, style = SavroButtonStyle.Secondary, loadingStateDescription = "")
+            SavroButton(label = "Duplicar", onClick = aoDuplicar, style = SavroButtonStyle.Secondary, loadingStateDescription = "")
+        }
+        Row(
+            modifier = Modifier.padding(top = SavroThemeTokens.spacing.sm),
+            horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm),
+        ) {
+            SavroButton(
+                label = if (item.arquivado) "Desarquivar" else "Arquivar",
+                onClick = aoArquivar,
+                style = SavroButtonStyle.Secondary,
+                loadingStateDescription = "",
+            )
+            SavroButton(label = "Excluir", onClick = aoExcluir, style = SavroButtonStyle.Destructive, loadingStateDescription = "")
+        }
+    }
+}
+
+/**
+ * Formulário de criação/edição (issue #119). [rememberSaveable] com [RascunhoFormularioItem]
+ * como serializador guarda o rascunho através de recriação de processo/Activity no Android; a
+ * mesma chamada em Compose Multiplatform depende do host iOS registrar um `SaveableStateRegistry`
+ * equivalente para sobreviver a transições de cena — contrato e adapter descritos na issue #119
+ * (parte entregue por Igor no `iosMain`).
+ */
+@Composable
+private fun TelaFormularioItem(
+    servico: ServicoPatrimonio,
+    itemIdEmEdicao: String?,
+    aoSalvar: () -> Unit,
+    aoCancelar: () -> Unit,
+) {
+    val itens by servico.itens.collectAsState()
+    val itemOriginal = remember(itemIdEmEdicao, itens) { itens.firstOrNull { it.id == itemIdEmEdicao } }
+
+    var estado by rememberSaveable(
+        stateSaver = Saver(
+            save = { RascunhoFormularioItem.serializar(it) },
+            restore = { RascunhoFormularioItem.restaurar(it) },
+        ),
+    ) {
+        mutableStateOf(itemOriginal?.paraEstadoDeFormulario() ?: EstadoFormularioItemPatrimonial())
+    }
+
+    var mostrarResumo by rememberSaveable { mutableStateOf(false) }
+    var erros by remember { mutableStateOf<List<ErroValidacaoItem>>(emptyList()) }
+    var salvando by remember { mutableStateOf(false) }
+    val escopo = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.md),
+    ) {
+        SavroText(if (itemIdEmEdicao == null) "Novo item" else "Editar item", style = SavroTextStyle.Headline)
+
+        if (mostrarResumo) {
+            val validado = ValidadorItemPatrimonial.validar(estado)
+            if (validado is Resultado.Sucesso) {
+                val resumo = ResumoItemPatrimonial.de(validado.valor)
+                PainelResumo(resumo)
+                Row(horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+                    SavroButton(
+                        label = "Voltar e editar",
+                        onClick = { mostrarResumo = false },
+                        style = SavroButtonStyle.Secondary,
+                        loadingStateDescription = "",
+                    )
+                    SavroButton(
+                        label = "Salvar",
+                        loading = salvando,
+                        loadingStateDescription = "Salvando",
+                        onClick = {
+                            salvando = true
+                            escopo.launch {
+                                val resultado = if (itemIdEmEdicao == null) {
+                                    servico.criar(estado.copy(itemIdEmEdicao = null))
+                                } else {
+                                    servico.editar(estado.copy(itemIdEmEdicao = itemIdEmEdicao))
+                                }
+                                salvando = false
+                                when (resultado) {
+                                    is Resultado.Sucesso -> aoSalvar()
+                                    is Resultado.Falha -> {
+                                        val erroServico = resultado.erro
+                                        erros = if (erroServico is ErroServicoPatrimonio.ValidacaoFalhou) {
+                                            erroServico.erros
+                                        } else {
+                                            emptyList()
+                                        }
+                                        mostrarResumo = false
+                                    }
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+        } else {
+            FormularioCampos(estado = estado, aoAlterar = { estado = it }, erros = erros)
+            Row(horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+                SavroButton(label = "Cancelar", onClick = aoCancelar, style = SavroButtonStyle.Secondary, loadingStateDescription = "")
+                SavroButton(
+                    label = "Revisar",
+                    onClick = {
+                        val resultado = ValidadorItemPatrimonial.validar(estado)
+                        when (resultado) {
+                            is Resultado.Sucesso -> {
+                                erros = emptyList()
+                                mostrarResumo = true
+                            }
+                            is Resultado.Falha -> erros = resultado.erro
+                        }
+                    },
+                    loadingStateDescription = "",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FormularioCampos(
+    estado: EstadoFormularioItemPatrimonial,
+    aoAlterar: (EstadoFormularioItemPatrimonial) -> Unit,
+    erros: List<ErroValidacaoItem>,
+) {
+    val camposVisiveis = estado.camposVisiveis()
+
+    Row(horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+        TipoItemPatrimonial.entries.forEach { tipo ->
+            SavroFilterChip(
+                label = rotuloDoTipo(tipo),
+                selected = estado.tipo == tipo,
+                onClick = { aoAlterar(estado.copy(tipo = tipo)) },
+            )
+        }
+    }
+
+    if (CampoFormularioItem.NOME in camposVisiveis) {
+        SavroTextField(
+            value = estado.nome,
+            onValueChange = { aoAlterar(estado.copy(nome = it)) },
+            label = "Nome",
+            isError = erros.any { it is ErroValidacaoItem.NomeObrigatorio || it is ErroValidacaoItem.NomeMuitoLongo },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    if (CampoFormularioItem.VALOR in camposVisiveis) {
+        SavroTextField(
+            value = estado.valorTexto,
+            onValueChange = { aoAlterar(estado.copy(valorTexto = it)) },
+            label = if (estado.tipo == TipoItemPatrimonial.DIVIDA) "Valor da dívida (negativo)" else "Valor atual",
+            isError = erros.any {
+                it is ErroValidacaoItem.ValorObrigatorio || it is ErroValidacaoItem.ValorNaoPodeSerNegativo ||
+                    it is ErroValidacaoItem.ValorDeDividaDeveSerNegativoOuZero
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    if (CampoFormularioItem.MOEDA in camposVisiveis) {
+        SavroTextField(
+            value = estado.moeda,
+            onValueChange = { aoAlterar(estado.copy(moeda = it)) },
+            label = "Moeda (ex.: BRL)",
+            isError = erros.any { it is ErroValidacaoItem.MoedaObrigatoria || it is ErroValidacaoItem.MoedaInvalida },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    if (CampoFormularioItem.QUANTIDADE in camposVisiveis) {
+        SavroTextField(
+            value = estado.quantidadeTexto,
+            onValueChange = { aoAlterar(estado.copy(quantidadeTexto = it)) },
+            label = "Quantidade (opcional)",
+            isError = erros.any { it is ErroValidacaoItem.QuantidadeDeveSerPositiva },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    if (CampoFormularioItem.PRECO_MEDIO in camposVisiveis) {
+        SavroTextField(
+            value = estado.precoMedioTexto,
+            onValueChange = { aoAlterar(estado.copy(precoMedioTexto = it)) },
+            label = "Preço médio (opcional)",
+            isError = erros.any { it is ErroValidacaoItem.PrecoMedioDeveSerPositivo },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    if (CampoFormularioItem.INSTITUICAO in camposVisiveis) {
+        SavroTextField(
+            value = estado.instituicao,
+            onValueChange = { aoAlterar(estado.copy(instituicao = it)) },
+            label = "Instituição (opcional)",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+    if (CampoFormularioItem.OBSERVACAO in camposVisiveis) {
+        SavroTextField(
+            value = estado.observacao,
+            onValueChange = { aoAlterar(estado.copy(observacao = it)) },
+            label = "Observação (opcional)",
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun PainelResumo(resumo: ResumoItemPatrimonial) {
+    SavroCard(modifier = Modifier.fillMaxWidth()) {
+        SavroText("Confira antes de salvar", style = SavroTextStyle.Title)
+        SavroText("${rotuloDoTipo(resumo.tipo)} · ${resumo.nome}", style = SavroTextStyle.Body)
+        SavroText("${resumo.valorFormatado} ${resumo.moeda}", style = SavroTextStyle.Body)
+        resumo.instituicao?.let { SavroText(it, style = SavroTextStyle.BodySmall) }
+        resumo.observacao?.let { SavroText(it, style = SavroTextStyle.BodySmall) }
+        resumo.quantidadeFormatada?.let { SavroText("Quantidade: $it", style = SavroTextStyle.BodySmall) }
+        resumo.precoMedioFormatado?.let { SavroText("Preço médio: $it", style = SavroTextStyle.BodySmall) }
+    }
+}
+
+@Composable
+private fun TelaAjusteDeValor(servico: ServicoPatrimonio, itemId: String, aoConcluir: () -> Unit) {
+    val itens by servico.itens.collectAsState()
+    val item = itens.firstOrNull { it.id == itemId }
+    var novoValorTexto by rememberSaveable(itemId) { mutableStateOf("") }
+    var erro by remember { mutableStateOf<String?>(null) }
+    var salvando by remember { mutableStateOf(false) }
+    val escopo = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.md),
+    ) {
+        SavroText("Ajustar valor", style = SavroTextStyle.Headline)
+        if (item != null) {
+            SavroText("${item.nome} · valor atual: ${formatarValor(item)} ${item.moeda}", style = SavroTextStyle.Body)
+        }
+        SavroTextField(
+            value = novoValorTexto,
+            onValueChange = { novoValorTexto = it },
+            label = "Novo valor",
+            isError = erro != null,
+            supportingText = erro,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+            SavroButton(label = "Cancelar", onClick = aoConcluir, style = SavroButtonStyle.Secondary, loadingStateDescription = "")
+            SavroButton(
+                label = "Confirmar ajuste",
+                loading = salvando,
+                loadingStateDescription = "Salvando",
+                onClick = {
+                    salvando = true
+                    escopo.launch {
+                        when (val resultado = servico.ajustarValor(itemId, novoValorTexto)) {
+                            is Resultado.Sucesso -> aoConcluir()
+                            is Resultado.Falha -> erro = "Não foi possível salvar o ajuste"
+                        }
+                        salvando = false
+                    }
+                },
+            )
+        }
+    }
+}
+
+private fun ItemPatrimonial.paraEstadoDeFormulario(): EstadoFormularioItemPatrimonial =
+    EstadoFormularioItemPatrimonial(
+        itemIdEmEdicao = id,
+        tipo = tipo,
+        nome = nome,
+        valorTexto = ConversorMonetario.centavosParaTexto(valorCentavos),
+        moeda = moeda,
+        instituicao = instituicao.orEmpty(),
+        observacao = observacao.orEmpty(),
+        quantidadeTexto = quantidadeMilesimos?.let { ConversorMonetario.quantidadeMilesimosParaTexto(it) }.orEmpty(),
+        precoMedioTexto = precoMedioCentavos?.let { ConversorMonetario.centavosParaTexto(it) }.orEmpty(),
+    )
+
+private fun formatarValor(item: ItemPatrimonial): String =
+    ConversorMonetario.centavosParaTexto(item.valorCentavos)
+
+private fun rotuloDoTipo(tipo: TipoItemPatrimonial): String = when (tipo) {
+    TipoItemPatrimonial.CONTA -> "Conta"
+    TipoItemPatrimonial.RENDA_VARIAVEL -> "Renda variável"
+    TipoItemPatrimonial.RENDA_FIXA -> "Renda fixa"
+    TipoItemPatrimonial.CRIPTO -> "Cripto"
+    TipoItemPatrimonial.BEM -> "Bem"
+    TipoItemPatrimonial.DIVIDA -> "Dívida"
+    TipoItemPatrimonial.OUTRO -> "Outro"
+}

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/PatrimonioScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/PatrimonioScreens.kt
@@ -54,11 +54,34 @@ private sealed class DestinoPatrimonio {
     data object Lista : DestinoPatrimonio()
     data class Formulario(val itemIdEmEdicao: String?) : DestinoPatrimonio()
     data class Ajuste(val itemId: String) : DestinoPatrimonio()
+
+    /**
+     * Serialização mínima para [rememberSaveable] — sem isso, `destino` reseta para [Lista] em
+     * qualquer recriação de processo (Android) ou perda de estado em memória (iOS), mesmo que o
+     * rascunho do formulário em si (`RascunhoFormularioItem`) sobreviva: sem saber que o destino
+     * era o formulário, a tela nunca chega a restaurá-lo (achado da revisão da fatia iOS, #119).
+     */
+    fun paraChave(): String = when (this) {
+        Lista -> ""
+        is Formulario -> "formulario:${itemIdEmEdicao.orEmpty()}"
+        is Ajuste -> "ajuste:$itemId"
+    }
+
+    companion object {
+        fun deChave(chave: String): DestinoPatrimonio = when {
+            chave.isEmpty() -> Lista
+            chave.startsWith("formulario:") -> Formulario(chave.removePrefix("formulario:").takeIf { it.isNotEmpty() })
+            chave.startsWith("ajuste:") -> Ajuste(chave.removePrefix("ajuste:"))
+            else -> Lista
+        }
+    }
 }
 
 @Composable
 internal fun TelaPatrimonio(servico: ServicoPatrimonio, aoAbrirConfiguracaoProtecao: () -> Unit) {
-    var destino by remember { mutableStateOf<DestinoPatrimonio>(DestinoPatrimonio.Lista) }
+    var destino by rememberSaveable(
+        stateSaver = Saver(save = { it.paraChave() }, restore = { DestinoPatrimonio.deChave(it) }),
+    ) { mutableStateOf<DestinoPatrimonio>(DestinoPatrimonio.Lista) }
 
     LaunchedEffect(servico) { servico.carregar() }
 
@@ -217,10 +240,15 @@ private fun ItemPatrimonialCard(
 
 /**
  * Formulário de criação/edição (issue #119). [rememberSaveable] com [RascunhoFormularioItem]
- * como serializador guarda o rascunho através de recriação de processo/Activity no Android; a
- * mesma chamada em Compose Multiplatform depende do host iOS registrar um `SaveableStateRegistry`
- * equivalente para sobreviver a transições de cena — contrato e adapter descritos na issue #119
- * (parte entregue por Igor no `iosMain`).
+ * como serializador guarda o rascunho através de recriação de Activity no Android (via
+ * `SavedStateRegistry` nativo) e, no iOS, através de qualquer recomposição enquanto o app segue
+ * vivo (background→foreground, cofre relockar/desbloquear) — o `ComposeUIViewController` do host
+ * iOS não precisou de adapter nativo adicional; decisão e motivo documentados em
+ * `SavroViewController.kt`/`SavroAppViewController()` (investigação de Igor, #119). `destino`, em
+ * [TelaPatrimonio], também usa `rememberSaveable` — sem isso, a navegação até o formulário se
+ * perderia antes mesmo do rascunho importar. Em ambas as plataformas, só a morte total do processo
+ * pelo sistema operacional (não coberta por nenhum `Saver` em memória) ainda perde o rascunho —
+ * risco de arquitetura registrado, não exclusivo de nenhuma plataforma.
  */
 @Composable
 private fun TelaFormularioItem(

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/SavroApp.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/SavroApp.kt
@@ -10,6 +10,7 @@ import io.savro.designsystem.componentes.SavroState
 import io.savro.designsystem.componentes.SavroStatePanel
 import io.savro.designsystem.componentes.SavroSurface
 import io.savro.designsystem.tema.SavroTheme
+import io.savro.domain.patrimonio.ServicoPatrimonio
 import io.savro.security.GerenciadorCofre
 import org.jetbrains.compose.resources.stringResource
 import io.savro.app.recursos.Res
@@ -19,10 +20,11 @@ import io.savro.app.recursos.cofre_verificando
  * Raiz compartilhada consumida pelo host Android (Activity) e pelo host iOS (UIViewController).
  * [gerenciador] já vem construído pelo host com as implementações nativas do cofre (#118) —
  * `:shared:app` não conhece Keystore, Keychain, BiometricPrompt nem LAContext, só o contrato
- * comum de `:shared:core:security`.
+ * comum de `:shared:core:security`. [servicoPatrimonio] (issue #119) compartilha a mesma conexão
+ * de banco já aberta pelo cofre.
  */
 @Composable
-fun SavroApp(gerenciador: GerenciadorCofre) {
+fun SavroApp(gerenciador: GerenciadorCofre, servicoPatrimonio: ServicoPatrimonio) {
     SavroTheme {
         var verificandoOnboarding by remember { mutableStateOf(true) }
         var onboardingConcluido by remember { mutableStateOf(false) }
@@ -47,7 +49,7 @@ fun SavroApp(gerenciador: GerenciadorCofre) {
                         gerenciador.iniciar()
                     },
                 )
-                else -> TelaCofre(gerenciador)
+                else -> TelaCofre(gerenciador, servicoPatrimonio)
             }
         }
     }

--- a/aplicativo/shared/app/src/iosMain/kotlin/io/savro/app/ComposicaoCofreIOS.kt
+++ b/aplicativo/shared/app/src/iosMain/kotlin/io/savro/app/ComposicaoCofreIOS.kt
@@ -3,6 +3,7 @@ package io.savro.app
 import io.savro.database.ProvedorChaveMestraIOS
 import io.savro.database.RelogioDoSistemaIOS
 import io.savro.database.RepositorioItensPatrimoniaisSQLCipher
+import io.savro.domain.patrimonio.ServicoPatrimonio
 import io.savro.security.AutenticadorBiometricoIOS
 import io.savro.security.GerenciadorCofre
 import io.savro.security.PreferenciasCofreIOS
@@ -21,17 +22,20 @@ import kotlinx.coroutines.SupervisorJob
 internal object ComposicaoCofreIOS {
     private val escopo = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
+    private val provedorChaveMestra by lazy { ProvedorChaveMestraIOS() }
+    private val repositorio by lazy { RepositorioItensPatrimoniaisSQLCipher(provedorChaveMestra, RelogioDoSistemaIOS) }
+
     val gerenciadorCofre: GerenciadorCofre by lazy {
-        val provedorChaveMestra = ProvedorChaveMestraIOS()
-        val repositorio = RepositorioItensPatrimoniaisSQLCipher(provedorChaveMestra, RelogioDoSistemaIOS)
-        val preferencias = PreferenciasCofreIOS()
         GerenciadorCofre(
             provedorChaveMestra = provedorChaveMestra,
             repositorio = repositorio,
             autenticador = AutenticadorBiometricoIOS(),
-            preferencias = preferencias,
+            preferencias = PreferenciasCofreIOS(),
             relogio = RelogioDoSistemaIOS,
             escopo = escopo,
         )
     }
+
+    /** Cadastro manual de patrimônio (issue #119) — mesma conexão de banco do [gerenciadorCofre]. */
+    val servicoPatrimonio: ServicoPatrimonio by lazy { ServicoPatrimonio(repositorio, RelogioDoSistemaIOS) }
 }

--- a/aplicativo/shared/app/src/iosMain/kotlin/io/savro/app/SavroViewController.kt
+++ b/aplicativo/shared/app/src/iosMain/kotlin/io/savro/app/SavroViewController.kt
@@ -9,6 +9,33 @@ import platform.UIKit.UIViewController
  * O host iOS não conhece regra de negócio — só embrulha esta view controller e encaminha
  * transições de ciclo de vida para [gerenciadorCofreParaCicloDeVida] (#118: bloqueio automático ao
  * sair/voltar do segundo plano).
+ *
+ * ## Preservação de rascunho de formulário em background/retorno (#119, investigação de Igor)
+ * `TelaFormularioItem` (`PatrimonioScreens.kt`) usa `rememberSaveable` com `RascunhoFormularioItem`
+ * como Saver. Isso **não precisa de adapter nativo adicional aqui**: o `UIViewController` retornado
+ * por `ComposeUIViewController` — e o `SaveableStateRegistry` que ele cria internamente — só é
+ * criado uma vez, na primeira chamada a esta função, e vive enquanto o processo do app viver.
+ * `ContentView.swift` mantém `ComposeView()` na mesma posição estrutural da `ZStack` em qualquer
+ * fase de `scenePhase` (só o overlay de proteção de snapshot entra/sai ao lado dela) — o SwiftUI
+ * nunca invalida a identidade de `ComposeView`, então nunca chama `makeUIViewController` de novo, e
+ * este `UIViewController` nunca é recriado por background→foreground nem por qualquer transição de
+ * cena comum. Ou seja: o mesmo processo Compose Multiplatform que já sobrevive à composição de
+ * `TelaFormularioItem` ser removida/recolocada (ex.: cofre relockar em #118 e o usuário reabrir o
+ * formulário depois de desbloquear) também sobrevive à app ir para segundo plano e voltar.
+ *
+ * O que isso **não** cobre — e nenhum adapter em `iosMain` cobriria sozinho, porque é limitação de
+ * `commonMain`, não de plataforma: o `SaveableStateRegistry` do Compose Multiplatform em iOS é só
+ * em memória (ao contrário do `Bundle`/`SavedStateRegistry` do Android, que o próprio SO persiste
+ * em disco). Se o sistema operacional finalizar o processo em segundo plano (pressão de memória) ou
+ * o usuário forçar o fechamento do app, um relançamento é um processo novo — `rememberSaveable`
+ * nunca chega a restaurar nada porque nada foi persistido. Isso não é lacuna exclusiva do iOS: no
+ * Android o mesmo cenário de morte de processo em segundo plano (não a rotação normal, que já era
+ * coberta) também perderia o estado se `destino`/rascunho não estivessem em `rememberSaveable`.
+ * `TelaPatrimonio.destino` (`PatrimonioScreens.kt`) foi corrigido para `rememberSaveable` depois
+ * desta investigação — restam cobertas as transições normais de lifecycle (background/retorno,
+ * rotação, recomposição). Persistência em disco sobrevivendo a **qualquer** morte de processo (o
+ * SO descartando o app inteiro por pressão de memória) é decisão de arquitetura maior, fora do
+ * escopo desta issue, registrada como risco pendente.
  */
 @Suppress("FunctionName")
 fun SavroAppViewController(): UIViewController =

--- a/aplicativo/shared/app/src/iosMain/kotlin/io/savro/app/SavroViewController.kt
+++ b/aplicativo/shared/app/src/iosMain/kotlin/io/savro/app/SavroViewController.kt
@@ -12,7 +12,12 @@ import platform.UIKit.UIViewController
  */
 @Suppress("FunctionName")
 fun SavroAppViewController(): UIViewController =
-    ComposeUIViewController { SavroApp(gerenciador = ComposicaoCofreIOS.gerenciadorCofre) }
+    ComposeUIViewController {
+        SavroApp(
+            gerenciador = ComposicaoCofreIOS.gerenciadorCofre,
+            servicoPatrimonio = ComposicaoCofreIOS.servicoPatrimonio,
+        )
+    }
 
 /**
  * Exposto para `iOSApp.swift` acompanhar `scenePhase` e chamar

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/EntidadeItemPatrimonial.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/EntidadeItemPatrimonial.kt
@@ -2,8 +2,12 @@ package io.savro.database
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
+import io.savro.model.AjusteValorItem
 import io.savro.model.ItemPatrimonial
+import io.savro.model.OrigemValor
 import io.savro.model.TipoItemPatrimonial
 
 /**
@@ -19,12 +23,46 @@ data class EntidadeItemPatrimonial(
     val nome: String,
     @ColumnInfo(name = "valor_centavos")
     val valorCentavos: Long,
+    val moeda: String,
     val instituicao: String?,
     val observacao: String?,
+    @ColumnInfo(name = "quantidade_milesimos")
+    val quantidadeMilesimos: Long?,
+    @ColumnInfo(name = "preco_medio_centavos")
+    val precoMedioCentavos: Long?,
+    val origem: String,
+    val arquivado: Boolean,
     @ColumnInfo(name = "criado_em_epoca_ms")
     val criadoEmEpocaMs: Long,
     @ColumnInfo(name = "atualizado_em_epoca_ms")
     val atualizadoEmEpocaMs: Long,
+)
+
+/** Histórico append-only de ajustes manuais de valor (issue #119) — nunca editado nem removido. */
+@Entity(
+    tableName = "ajustes_valor_item",
+    foreignKeys = [
+        ForeignKey(
+            entity = EntidadeItemPatrimonial::class,
+            parentColumns = ["id"],
+            childColumns = ["item_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("item_id")],
+)
+data class EntidadeAjusteValorItem(
+    @PrimaryKey
+    val id: String,
+    @ColumnInfo(name = "item_id")
+    val itemId: String,
+    @ColumnInfo(name = "valor_centavos_anterior")
+    val valorCentavosAnterior: Long,
+    @ColumnInfo(name = "valor_centavos_novo")
+    val valorCentavosNovo: Long,
+    val origem: String,
+    @ColumnInfo(name = "data_epoca_ms")
+    val dataEpocaMs: Long,
 )
 
 internal fun EntidadeItemPatrimonial.paraModelo(): ItemPatrimonial = ItemPatrimonial(
@@ -32,8 +70,13 @@ internal fun EntidadeItemPatrimonial.paraModelo(): ItemPatrimonial = ItemPatrimo
     tipo = TipoItemPatrimonial.valueOf(tipo),
     nome = nome,
     valorCentavos = valorCentavos,
+    moeda = moeda,
     instituicao = instituicao,
     observacao = observacao,
+    quantidadeMilesimos = quantidadeMilesimos,
+    precoMedioCentavos = precoMedioCentavos,
+    origem = OrigemValor.valueOf(origem),
+    arquivado = arquivado,
     criadoEmEpocaMs = criadoEmEpocaMs,
     atualizadoEmEpocaMs = atualizadoEmEpocaMs,
 )
@@ -43,8 +86,22 @@ internal fun ItemPatrimonial.paraEntidade(): EntidadeItemPatrimonial = EntidadeI
     tipo = tipo.name,
     nome = nome,
     valorCentavos = valorCentavos,
+    moeda = moeda,
     instituicao = instituicao,
     observacao = observacao,
+    quantidadeMilesimos = quantidadeMilesimos,
+    precoMedioCentavos = precoMedioCentavos,
+    origem = origem.name,
+    arquivado = arquivado,
     criadoEmEpocaMs = criadoEmEpocaMs,
     atualizadoEmEpocaMs = atualizadoEmEpocaMs,
+)
+
+internal fun EntidadeAjusteValorItem.paraModelo(): AjusteValorItem = AjusteValorItem(
+    id = id,
+    itemId = itemId,
+    valorCentavosAnterior = valorCentavosAnterior,
+    valorCentavosNovo = valorCentavosNovo,
+    origem = OrigemValor.valueOf(origem),
+    dataEpocaMs = dataEpocaMs,
 )

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/ItemPatrimonialDao.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/ItemPatrimonialDao.kt
@@ -28,4 +28,13 @@ internal interface ItemPatrimonialDao {
 
     @Query("SELECT COUNT(*) FROM itens_patrimoniais")
     suspend fun contar(): Int
+
+    @Query("UPDATE itens_patrimoniais SET valor_centavos = :valorCentavos, atualizado_em_epoca_ms = :dataEpocaMs WHERE id = :id")
+    suspend fun atualizarValor(id: String, valorCentavos: Long, dataEpocaMs: Long): Int
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun inserirAjuste(entidade: EntidadeAjusteValorItem)
+
+    @Query("SELECT * FROM ajustes_valor_item WHERE item_id = :itemId ORDER BY data_epoca_ms ASC")
+    suspend fun listarAjustes(itemId: String): List<EntidadeAjusteValorItem>
 }

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisRoom.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisRoom.kt
@@ -9,8 +9,10 @@ import io.savro.common.Relogio
 import io.savro.common.Resultado
 import io.savro.domain.patrimonio.ErroRepositorio
 import io.savro.domain.patrimonio.ProvedorChaveMestra
+import io.savro.domain.patrimonio.GeradorIdItem
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
+import io.savro.model.AjusteValorItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
 import java.util.Arrays
@@ -129,6 +131,44 @@ class RepositorioItensPatrimoniaisRoom(
 
     override suspend fun listarTodos(): Resultado<List<ItemPatrimonial>, ErroRepositorio> =
         comBancoAberto { dao -> Resultado.Sucesso(dao.listarTodos().map { it.paraModelo() }) }
+
+    override suspend fun registrarAjusteDeValor(
+        itemId: String,
+        novoValorCentavos: Long,
+        dataEpocaMs: Long,
+    ): Resultado<ItemPatrimonial, ErroRepositorio> {
+        val instancia = banco ?: return Resultado.Falha(
+            ErroRepositorio.FalhaAbertura("Repositório chamado antes de abrir()"),
+        )
+        val dao = instancia.itemPatrimonialDao()
+        return try {
+            val itemAtualizado = instancia.withTransaction {
+                val existente = dao.buscarPorId(itemId) ?: error("item-nao-encontrado")
+                dao.inserirAjuste(
+                    EntidadeAjusteValorItem(
+                        id = GeradorIdItem.novoId(),
+                        itemId = itemId,
+                        valorCentavosAnterior = existente.valorCentavos,
+                        valorCentavosNovo = novoValorCentavos,
+                        origem = existente.origem,
+                        dataEpocaMs = dataEpocaMs,
+                    ),
+                )
+                dao.atualizarValor(itemId, novoValorCentavos, dataEpocaMs)
+                existente.copy(valorCentavos = novoValorCentavos, atualizadoEmEpocaMs = dataEpocaMs)
+            }
+            Resultado.Sucesso(itemAtualizado.paraModelo())
+        } catch (excecao: Exception) {
+            if (excecao.message == "item-nao-encontrado") {
+                Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(itemId))
+            } else {
+                Resultado.Falha(ErroRepositorio.FalhaTransacao(excecao.message ?: "Transação revertida"))
+            }
+        }
+    }
+
+    override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
+        comBancoAberto { dao -> Resultado.Sucesso(dao.listarAjustes(itemId).map { it.paraModelo() }) }
 
     override suspend fun executarEmTransacao(
         bloco: suspend TransacaoItensPatrimoniais.() -> Unit,

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/SavroRoomDatabase.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/SavroRoomDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [EntidadeItemPatrimonial::class],
+    entities = [EntidadeItemPatrimonial::class, EntidadeAjusteValorItem::class],
     version = EsquemaSavro.VERSAO_ATUAL,
     exportSchema = true,
 )
@@ -24,4 +24,40 @@ internal val MIGRATION_1_2: Migration = object : Migration(1, 2) {
     }
 }
 
-internal val TODAS_AS_MIGRATIONS_ROOM: Array<Migration> = arrayOf(MIGRATION_1_2)
+/**
+ * Cadastro manual de patrimônio (#119, ver [EsquemaSavro]). `tipo` é remapeado antes de qualquer
+ * outra alteração para preservar dados já persistidos pela #180 (schema mínimo original):
+ * `INVESTIMENTO -> RENDA_VARIAVEL`, `IMOVEL`/`VEICULO -> BEM`. `CONTA` e `OUTRO` não mudam de
+ * nome. `moeda` recebe `'BRL'` como valor por padrão nas linhas existentes (produto brasileiro,
+ * sem dado de moeda anterior a esta migration). `origem` recebe `'MANUAL'` — único valor possível
+ * até #124/#125 introduzirem outra origem.
+ */
+internal val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("UPDATE itens_patrimoniais SET tipo = 'RENDA_VARIAVEL' WHERE tipo = 'INVESTIMENTO'")
+        db.execSQL("UPDATE itens_patrimoniais SET tipo = 'BEM' WHERE tipo IN ('IMOVEL', 'VEICULO')")
+
+        db.execSQL("ALTER TABLE itens_patrimoniais ADD COLUMN moeda TEXT NOT NULL DEFAULT 'BRL'")
+        db.execSQL("ALTER TABLE itens_patrimoniais ADD COLUMN quantidade_milesimos INTEGER")
+        db.execSQL("ALTER TABLE itens_patrimoniais ADD COLUMN preco_medio_centavos INTEGER")
+        db.execSQL("ALTER TABLE itens_patrimoniais ADD COLUMN origem TEXT NOT NULL DEFAULT 'MANUAL'")
+        db.execSQL("ALTER TABLE itens_patrimoniais ADD COLUMN arquivado INTEGER NOT NULL DEFAULT 0")
+
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS ajustes_valor_item (
+              id TEXT NOT NULL PRIMARY KEY,
+              item_id TEXT NOT NULL,
+              valor_centavos_anterior INTEGER NOT NULL,
+              valor_centavos_novo INTEGER NOT NULL,
+              origem TEXT NOT NULL,
+              data_epoca_ms INTEGER NOT NULL,
+              FOREIGN KEY(item_id) REFERENCES itens_patrimoniais(id) ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_ajustes_valor_item_item_id ON ajustes_valor_item(item_id)")
+    }
+}
+
+internal val TODAS_AS_MIGRATIONS_ROOM: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3)

--- a/aplicativo/shared/core/database/src/androidUnitTest/kotlin/io/savro/database/RoomMigrationTest.kt
+++ b/aplicativo/shared/core/database/src/androidUnitTest/kotlin/io/savro/database/RoomMigrationTest.kt
@@ -51,6 +51,30 @@ internal abstract class SavroRoomDatabaseV1SomenteParaTeste : RoomDatabase() {
     abstract fun dao(): DaoItemPatrimonialV1
 }
 
+/** Schema exato da versão 2 (pós #180, pré #119) — usado para testar a migration 2->3. */
+@Entity(tableName = "itens_patrimoniais")
+internal data class EntidadeItemPatrimonialV2(
+    @PrimaryKey val id: String,
+    val tipo: String,
+    val nome: String,
+    @ColumnInfo(name = "valor_centavos") val valorCentavos: Long,
+    val instituicao: String?,
+    val observacao: String?,
+    @ColumnInfo(name = "criado_em_epoca_ms") val criadoEmEpocaMs: Long,
+    @ColumnInfo(name = "atualizado_em_epoca_ms") val atualizadoEmEpocaMs: Long,
+)
+
+@Dao
+internal interface DaoItemPatrimonialV2 {
+    @Insert
+    suspend fun inserir(entidade: EntidadeItemPatrimonialV2)
+}
+
+@Database(entities = [EntidadeItemPatrimonialV2::class], version = 2, exportSchema = false)
+internal abstract class SavroRoomDatabaseV2SomenteParaTeste : RoomDatabase() {
+    abstract fun dao(): DaoItemPatrimonialV2
+}
+
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class RoomMigrationTest {
@@ -98,6 +122,64 @@ class RoomMigrationTest {
         assertEquals("Nota adicionada após migration", itemAtualizado?.observacao)
 
         bancoV2.close()
+    }
+
+    @Test
+    fun migracao2Para3_remapeiaTiposPreservaDadosEAdicionaCamposDoCadastroManual() = runTest {
+        val arquivo = "teste-migracao-${UUID.randomUUID()}.db"
+        nomeArquivo = arquivo
+        val contexto = contexto()
+
+        val bancoV2 = Room.databaseBuilder(contexto, SavroRoomDatabaseV2SomenteParaTeste::class.java, arquivo)
+            .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .build()
+        bancoV2.dao().inserir(
+            EntidadeItemPatrimonialV2(
+                id = "item-investimento",
+                tipo = "INVESTIMENTO",
+                nome = "Ações XPTO",
+                valorCentavos = 50_000,
+                instituicao = "Corretora Teste",
+                observacao = null,
+                criadoEmEpocaMs = 1,
+                atualizadoEmEpocaMs = 1,
+            ),
+        )
+        bancoV2.dao().inserir(
+            EntidadeItemPatrimonialV2(
+                id = "item-imovel",
+                tipo = "IMOVEL",
+                nome = "Apartamento",
+                valorCentavos = 30_000_000,
+                instituicao = null,
+                observacao = "Comprado em 2020",
+                criadoEmEpocaMs = 2,
+                atualizadoEmEpocaMs = 2,
+            ),
+        )
+        bancoV2.close()
+
+        val bancoV3 = Room.databaseBuilder(contexto, SavroRoomDatabase::class.java, arquivo)
+            .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
+            .addMigrations(*TODAS_AS_MIGRATIONS_ROOM)
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .build()
+
+        val investimentoMigrado = bancoV3.itemPatrimonialDao().buscarPorId("item-investimento")
+        assertEquals("RENDA_VARIAVEL", investimentoMigrado?.tipo)
+        assertEquals("Ações XPTO", investimentoMigrado?.nome)
+        assertEquals(50_000L, investimentoMigrado?.valorCentavos)
+        assertEquals("BRL", investimentoMigrado?.moeda)
+        assertEquals("MANUAL", investimentoMigrado?.origem)
+        assertEquals(false, investimentoMigrado?.arquivado)
+        assertNull(investimentoMigrado?.quantidadeMilesimos)
+
+        val imovelMigrado = bancoV3.itemPatrimonialDao().buscarPorId("item-imovel")
+        assertEquals("BEM", imovelMigrado?.tipo)
+        assertEquals("Comprado em 2020", imovelMigrado?.observacao)
+
+        bancoV3.close()
     }
 
     private fun contexto(): Context = ApplicationProvider.getApplicationContext()

--- a/aplicativo/shared/core/database/src/commonMain/kotlin/io/savro/database/EsquemaSavro.kt
+++ b/aplicativo/shared/core/database/src/commonMain/kotlin/io/savro/database/EsquemaSavro.kt
@@ -11,13 +11,21 @@ package io.savro.database
  */
 object EsquemaSavro {
     const val NOME_BANCO = "savro.db"
-    const val VERSAO_ATUAL = 2
+    const val VERSAO_ATUAL = 3
 
     val migracoes: List<DescricaoMigracao> = listOf(
         DescricaoMigracao(
             versaoOrigem = 1,
             versaoDestino = 2,
             descricao = "Adiciona coluna opcional 'observacao' em itens_patrimoniais",
+        ),
+        DescricaoMigracao(
+            versaoOrigem = 2,
+            versaoDestino = 3,
+            descricao = "Cadastro manual de patrimônio (#119): adiciona 'moeda', 'quantidade_milesimos', " +
+                "'preco_medio_centavos', 'origem' e 'arquivado' em itens_patrimoniais; remapeia " +
+                "'INVESTIMENTO'->'RENDA_VARIAVEL' e 'IMOVEL'/'VEICULO'->'BEM' na coluna 'tipo'; cria a " +
+                "tabela 'ajustes_valor_item'",
         ),
     )
 }

--- a/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/FakeRepositorioItensPatrimoniais.kt
+++ b/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/FakeRepositorioItensPatrimoniais.kt
@@ -3,11 +3,13 @@ package io.savro.database
 import io.savro.common.Relogio
 import io.savro.common.Resultado
 import io.savro.domain.patrimonio.ErroRepositorio
-import io.savro.domain.patrimonio.ProvedorChaveMestra
+import io.savro.domain.patrimonio.GeradorIdItem
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
+import io.savro.model.AjusteValorItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
+import io.savro.domain.patrimonio.ProvedorChaveMestra
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -26,6 +28,7 @@ class FakeRepositorioItensPatrimoniais(
 
     private val mutex = Mutex()
     private val itens = LinkedHashMap<String, ItemPatrimonial>()
+    private val ajustes = mutableListOf<AjusteValorItem>()
     private var aberto = false
 
     override suspend fun abrir(): Resultado<MetadadosBancoLocal, ErroRepositorio> = mutex.withLock {
@@ -79,6 +82,34 @@ class FakeRepositorioItensPatrimoniais(
         exigirAberto()?.let { return@withLock Resultado.Falha(it) }
         Resultado.Sucesso(itens.values.toList())
     }
+
+    override suspend fun registrarAjusteDeValor(
+        itemId: String,
+        novoValorCentavos: Long,
+        dataEpocaMs: Long,
+    ): Resultado<ItemPatrimonial, ErroRepositorio> = mutex.withLock {
+        exigirAberto()?.let { return@withLock Resultado.Falha(it) }
+        val existente = itens[itemId] ?: return@withLock Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(itemId))
+
+        val ajuste = AjusteValorItem(
+            id = GeradorIdItem.novoId(),
+            itemId = itemId,
+            valorCentavosAnterior = existente.valorCentavos,
+            valorCentavosNovo = novoValorCentavos,
+            origem = existente.origem,
+            dataEpocaMs = dataEpocaMs,
+        )
+        val atualizado = existente.copy(valorCentavos = novoValorCentavos, atualizadoEmEpocaMs = dataEpocaMs)
+        ajustes += ajuste
+        itens[itemId] = atualizado
+        Resultado.Sucesso(atualizado)
+    }
+
+    override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
+        mutex.withLock {
+            exigirAberto()?.let { return@withLock Resultado.Falha(it) }
+            Resultado.Sucesso(ajustes.filter { it.itemId == itemId })
+        }
 
     override suspend fun executarEmTransacao(
         bloco: suspend TransacaoItensPatrimoniais.() -> Unit,

--- a/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/RepositorioItensPatrimoniaisContratoTeste.kt
+++ b/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/RepositorioItensPatrimoniaisContratoTeste.kt
@@ -3,7 +3,9 @@ package io.savro.database
 import io.savro.common.Resultado
 import io.savro.domain.patrimonio.ErroRepositorio
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
+import io.savro.model.AjusteValorItem
 import io.savro.model.ItemPatrimonial
+import io.savro.model.OrigemValor
 import io.savro.model.TipoItemPatrimonial
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -40,13 +42,19 @@ abstract class RepositorioItensPatrimoniaisContratoTeste {
         id: String = "item-1",
         nome: String = "Conta corrente",
         valorCentavos: Long = 123_456,
+        tipo: TipoItemPatrimonial = TipoItemPatrimonial.CONTA,
     ): ItemPatrimonial = ItemPatrimonial(
         id = id,
-        tipo = TipoItemPatrimonial.CONTA,
+        tipo = tipo,
         nome = nome,
         valorCentavos = valorCentavos,
+        moeda = "BRL",
         instituicao = "Banco Teste",
         observacao = null,
+        quantidadeMilesimos = null,
+        precoMedioCentavos = null,
+        origem = OrigemValor.MANUAL,
+        arquivado = false,
         criadoEmEpocaMs = 0,
         atualizadoEmEpocaMs = 0,
     )
@@ -249,6 +257,64 @@ abstract class RepositorioItensPatrimoniaisContratoTeste {
         assertIs<Resultado.Sucesso<List<ItemPatrimonial>>>(listagem)
         assertEquals(totalDeItens, listagem.valor.size)
         assertEquals(totalDeItens, listagem.valor.map { it.id }.toSet().size)
+
+        encerrar(repositorio)
+    }
+
+    @Test
+    fun arquivar_persisteFlagENaoAlteraOutrosCampos() = runTest {
+        val repositorio = criarRepositorio()
+        repositorio.abrir()
+        val item = itemDeTeste()
+        repositorio.inserir(item)
+
+        val arquivado = repositorio.atualizar(item.copy(arquivado = true))
+        assertIs<Resultado.Sucesso<ItemPatrimonial>>(arquivado)
+        assertTrue(arquivado.valor.arquivado)
+        assertEquals(item.nome, arquivado.valor.nome)
+
+        val buscado = repositorio.buscarPorId(item.id)
+        assertIs<Resultado.Sucesso<ItemPatrimonial?>>(buscado)
+        assertTrue(buscado.valor?.arquivado == true)
+
+        encerrar(repositorio)
+    }
+
+    @Test
+    fun registrarAjusteDeValor_atualizaItemEGravaHistoricoAtomicamente() = runTest {
+        val repositorio = criarRepositorio()
+        repositorio.abrir()
+        val item = itemDeTeste(valorCentavos = 1_000)
+        repositorio.inserir(item)
+
+        val resultado = repositorio.registrarAjusteDeValor(item.id, novoValorCentavos = 2_500, dataEpocaMs = 999)
+        assertIs<Resultado.Sucesso<ItemPatrimonial>>(resultado)
+        assertEquals(2_500L, resultado.valor.valorCentavos)
+        assertEquals(999L, resultado.valor.atualizadoEmEpocaMs)
+
+        val ajustes = repositorio.listarAjustesDeValor(item.id)
+        assertIs<Resultado.Sucesso<List<AjusteValorItem>>>(ajustes)
+        assertEquals(1, ajustes.valor.size)
+        assertEquals(1_000L, ajustes.valor.single().valorCentavosAnterior)
+        assertEquals(2_500L, ajustes.valor.single().valorCentavosNovo)
+        assertEquals(999L, ajustes.valor.single().dataEpocaMs)
+        assertEquals(OrigemValor.MANUAL, ajustes.valor.single().origem)
+
+        encerrar(repositorio)
+    }
+
+    @Test
+    fun registrarAjusteDeValor_itemInexistente_retornaItemNaoEncontradoENaoGravaAjuste() = runTest {
+        val repositorio = criarRepositorio()
+        repositorio.abrir()
+
+        val resultado = repositorio.registrarAjusteDeValor("nao-existe", novoValorCentavos = 1, dataEpocaMs = 1)
+        assertIs<Resultado.Falha<ErroRepositorio>>(resultado)
+        assertIs<ErroRepositorio.ItemNaoEncontrado>(resultado.erro)
+
+        val ajustes = repositorio.listarAjustesDeValor("nao-existe")
+        assertIs<Resultado.Sucesso<List<AjusteValorItem>>>(ajustes)
+        assertEquals(0, ajustes.valor.size)
 
         encerrar(repositorio)
     }

--- a/aplicativo/shared/core/database/src/iosMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisSQLCipher.kt
+++ b/aplicativo/shared/core/database/src/iosMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisSQLCipher.kt
@@ -3,11 +3,14 @@ package io.savro.database
 import io.savro.common.Relogio
 import io.savro.common.Resultado
 import io.savro.domain.patrimonio.ErroRepositorio
+import io.savro.domain.patrimonio.GeradorIdItem
 import io.savro.domain.patrimonio.ProvedorChaveMestra
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
+import io.savro.model.AjusteValorItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
+import io.savro.model.OrigemValor
 import io.savro.model.TipoItemPatrimonial
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.sync.Mutex
@@ -111,6 +114,51 @@ class RepositorioItensPatrimoniaisSQLCipher(
             Resultado.Sucesso(linhas.map(::linhaParaItem))
         }
 
+    override suspend fun registrarAjusteDeValor(
+        itemId: String,
+        novoValorCentavos: Long,
+        dataEpocaMs: Long,
+    ): Resultado<ItemPatrimonial, ErroRepositorio> = comBancoAberto { db ->
+        val existente = db.consultar("SELECT * FROM itens_patrimoniais WHERE id = '${itemId.escapado()}' LIMIT 1")
+            .firstOrNull()?.let(::linhaParaItem)
+            ?: return@comBancoAberto Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(itemId))
+
+        db.executar("BEGIN IMMEDIATE")
+        try {
+            db.executar(
+                """
+                INSERT INTO ajustes_valor_item
+                    (id, item_id, valor_centavos_anterior, valor_centavos_novo, origem, data_epoca_ms)
+                VALUES (
+                    '${GeradorIdItem.novoId().escapado()}',
+                    '${itemId.escapado()}',
+                    ${existente.valorCentavos},
+                    $novoValorCentavos,
+                    '${existente.origem.name}',
+                    $dataEpocaMs
+                )
+                """.trimIndent(),
+            )
+            db.executar(
+                "UPDATE itens_patrimoniais SET valor_centavos = $novoValorCentavos, " +
+                    "atualizado_em_epoca_ms = $dataEpocaMs WHERE id = '${itemId.escapado()}'",
+            )
+            db.executar("COMMIT")
+            Resultado.Sucesso(existente.copy(valorCentavos = novoValorCentavos, atualizadoEmEpocaMs = dataEpocaMs))
+        } catch (excecao: Exception) {
+            runCatching { db.executar("ROLLBACK") }
+            Resultado.Falha(ErroRepositorio.FalhaTransacao(excecao.message ?: "Transação revertida"))
+        }
+    }
+
+    override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
+        comBancoAberto { db ->
+            val linhas = db.consultar(
+                "SELECT * FROM ajustes_valor_item WHERE item_id = '${itemId.escapado()}' ORDER BY data_epoca_ms ASC",
+            )
+            Resultado.Sucesso(linhas.map(::linhaParaAjuste))
+        }
+
     override suspend fun executarEmTransacao(
         bloco: suspend TransacaoItensPatrimoniais.() -> Unit,
     ): Resultado<Unit, ErroRepositorio> {
@@ -158,13 +206,19 @@ class RepositorioItensPatrimoniaisSQLCipher(
                   tipo TEXT NOT NULL,
                   nome TEXT NOT NULL,
                   valor_centavos INTEGER NOT NULL,
+                  moeda TEXT NOT NULL DEFAULT 'BRL',
                   instituicao TEXT,
                   observacao TEXT,
+                  quantidade_milesimos INTEGER,
+                  preco_medio_centavos INTEGER,
+                  origem TEXT NOT NULL DEFAULT 'MANUAL',
+                  arquivado INTEGER NOT NULL DEFAULT 0,
                   criado_em_epoca_ms INTEGER NOT NULL,
                   atualizado_em_epoca_ms INTEGER NOT NULL
                 )
                 """.trimIndent(),
             )
+            criarTabelaDeAjustes(db)
             db.executar("PRAGMA user_version = ${EsquemaSavro.VERSAO_ATUAL}")
             return
         }
@@ -173,8 +227,38 @@ class RepositorioItensPatrimoniaisSQLCipher(
             if (versaoAtual < 2) {
                 db.executar("ALTER TABLE itens_patrimoniais ADD COLUMN observacao TEXT")
             }
+            if (versaoAtual < 3) {
+                // Cadastro manual de patrimônio (#119). Mesmo remapeamento de dados que a
+                // migration 2->3 do Android (MIGRATION_2_3 em SavroRoomDatabase.kt) — ver
+                // comentário lá para o motivo de cada remapeamento.
+                db.executar("UPDATE itens_patrimoniais SET tipo = 'RENDA_VARIAVEL' WHERE tipo = 'INVESTIMENTO'")
+                db.executar("UPDATE itens_patrimoniais SET tipo = 'BEM' WHERE tipo IN ('IMOVEL', 'VEICULO')")
+                db.executar("ALTER TABLE itens_patrimoniais ADD COLUMN moeda TEXT NOT NULL DEFAULT 'BRL'")
+                db.executar("ALTER TABLE itens_patrimoniais ADD COLUMN quantidade_milesimos INTEGER")
+                db.executar("ALTER TABLE itens_patrimoniais ADD COLUMN preco_medio_centavos INTEGER")
+                db.executar("ALTER TABLE itens_patrimoniais ADD COLUMN origem TEXT NOT NULL DEFAULT 'MANUAL'")
+                db.executar("ALTER TABLE itens_patrimoniais ADD COLUMN arquivado INTEGER NOT NULL DEFAULT 0")
+                criarTabelaDeAjustes(db)
+            }
             db.executar("PRAGMA user_version = ${EsquemaSavro.VERSAO_ATUAL}")
         }
+    }
+
+    private fun criarTabelaDeAjustes(db: SQLiteCifrado) {
+        db.executar(
+            """
+            CREATE TABLE IF NOT EXISTS ajustes_valor_item (
+              id TEXT NOT NULL PRIMARY KEY,
+              item_id TEXT NOT NULL,
+              valor_centavos_anterior INTEGER NOT NULL,
+              valor_centavos_novo INTEGER NOT NULL,
+              origem TEXT NOT NULL,
+              data_epoca_ms INTEGER NOT NULL,
+              FOREIGN KEY(item_id) REFERENCES itens_patrimoniais(id) ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.executar("CREATE INDEX IF NOT EXISTS index_ajustes_valor_item_item_id ON ajustes_valor_item(item_id)")
     }
 
     private fun mapearExcecaoDeAbertura(excecao: Exception): Resultado<MetadadosBancoLocal, ErroRepositorio> {
@@ -214,22 +298,42 @@ private fun linhaParaItem(linha: Map<String, String?>): ItemPatrimonial = ItemPa
     tipo = TipoItemPatrimonial.valueOf(linha.getValue("tipo") ?: error("linha sem tipo")),
     nome = linha.getValue("nome") ?: error("linha sem nome"),
     valorCentavos = linha.getValue("valor_centavos")?.toLong() ?: 0,
+    moeda = linha["moeda"] ?: "BRL",
     instituicao = linha["instituicao"],
     observacao = linha["observacao"],
+    quantidadeMilesimos = linha["quantidade_milesimos"]?.toLongOrNull(),
+    precoMedioCentavos = linha["preco_medio_centavos"]?.toLongOrNull(),
+    origem = linha["origem"]?.let { runCatching { OrigemValor.valueOf(it) }.getOrNull() } ?: OrigemValor.MANUAL,
+    arquivado = linha["arquivado"] == "1",
     criadoEmEpocaMs = linha.getValue("criado_em_epoca_ms")?.toLong() ?: 0,
     atualizadoEmEpocaMs = linha.getValue("atualizado_em_epoca_ms")?.toLong() ?: 0,
 )
 
+private fun linhaParaAjuste(linha: Map<String, String?>): AjusteValorItem = AjusteValorItem(
+    id = linha.getValue("id") ?: error("linha sem id"),
+    itemId = linha.getValue("item_id") ?: error("linha sem item_id"),
+    valorCentavosAnterior = linha.getValue("valor_centavos_anterior")?.toLong() ?: 0,
+    valorCentavosNovo = linha.getValue("valor_centavos_novo")?.toLong() ?: 0,
+    origem = linha["origem"]?.let { runCatching { OrigemValor.valueOf(it) }.getOrNull() } ?: OrigemValor.MANUAL,
+    dataEpocaMs = linha.getValue("data_epoca_ms")?.toLong() ?: 0,
+)
+
 private fun sqlInserir(item: ItemPatrimonial): String = """
     INSERT INTO itens_patrimoniais
-        (id, tipo, nome, valor_centavos, instituicao, observacao, criado_em_epoca_ms, atualizado_em_epoca_ms)
+        (id, tipo, nome, valor_centavos, moeda, instituicao, observacao, quantidade_milesimos,
+         preco_medio_centavos, origem, arquivado, criado_em_epoca_ms, atualizado_em_epoca_ms)
     VALUES (
         '${item.id.escapado()}',
         '${item.tipo.name}',
         '${item.nome.escapado()}',
         ${item.valorCentavos},
+        '${item.moeda.escapado()}',
         ${item.instituicao?.let { "'${it.escapado()}'" } ?: "NULL"},
         ${item.observacao?.let { "'${it.escapado()}'" } ?: "NULL"},
+        ${item.quantidadeMilesimos ?: "NULL"},
+        ${item.precoMedioCentavos ?: "NULL"},
+        '${item.origem.name}',
+        ${if (item.arquivado) 1 else 0},
         ${item.criadoEmEpocaMs},
         ${item.atualizadoEmEpocaMs}
     )
@@ -240,8 +344,12 @@ private fun sqlAtualizar(item: ItemPatrimonial): String = """
         tipo = '${item.tipo.name}',
         nome = '${item.nome.escapado()}',
         valor_centavos = ${item.valorCentavos},
+        moeda = '${item.moeda.escapado()}',
         instituicao = ${item.instituicao?.let { "'${it.escapado()}'" } ?: "NULL"},
         observacao = ${item.observacao?.let { "'${it.escapado()}'" } ?: "NULL"},
+        quantidade_milesimos = ${item.quantidadeMilesimos ?: "NULL"},
+        preco_medio_centavos = ${item.precoMedioCentavos ?: "NULL"},
+        arquivado = ${if (item.arquivado) 1 else 0},
         atualizado_em_epoca_ms = ${item.atualizadoEmEpocaMs}
     WHERE id = '${item.id.escapado()}'
 """.trimIndent()

--- a/aplicativo/shared/core/model/src/commonMain/kotlin/io/savro/model/ItemPatrimonial.kt
+++ b/aplicativo/shared/core/model/src/commonMain/kotlin/io/savro/model/ItemPatrimonial.kt
@@ -1,32 +1,88 @@
 package io.savro.model
 
 /**
- * Schema mínimo do cofre local, suficiente para provar persistência cifrada ponta a ponta
- * (#180). Regras completas de patrimônio (cálculo, histórico, score) não pertencem a esta issue.
+ * Tipos patrimoniais suportados no MVP1 (#119). Os cinco valores originais da #180
+ * (`CONTA`/`INVESTIMENTO`/`IMOVEL`/`VEICULO`/`OUTRO` — schema mínimo "suficiente para provar
+ * persistência cifrada ponta a ponta") são substituídos pela taxonomia real definida na issue.
+ * `INVESTIMENTO` vira `RENDA_VARIAVEL`; `IMOVEL`/`VEICULO` viram `BEM` (ver migration de schema
+ * `MIGRATION_2_3`/equivalente iOS, que remapeia dados já persistidos).
  */
 enum class TipoItemPatrimonial {
     CONTA,
-    INVESTIMENTO,
-    IMOVEL,
-    VEICULO,
+    RENDA_VARIAVEL,
+    RENDA_FIXA,
+    CRIPTO,
+    BEM,
+    DIVIDA,
     OUTRO,
 }
 
 /**
- * Item patrimonial persistido no cofre local. `valorCentavos` evita ponto flutuante em dado
- * financeiro. `instituicao` e `observacao` são opcionais e nunca aparecem em log — o repositório
- * de persistência é a única camada autorizada a lê-los em texto claro, e só depois do cofre
- * aberto com material criptográfico válido.
+ * Origem do valor de um item ou de um [AjusteValorItem]. MVP1 só cadastra manualmente (#119 é
+ * "cadastro manual"; catálogo/cotação automática é #124/#125, fora de escopo). O tipo existe para
+ * que a origem seja um dado explícito e auditável desde já, não um valor implícito assumido em
+ * todo lugar que precisar dele.
+ */
+enum class OrigemValor {
+    MANUAL,
+}
+
+/**
+ * Item patrimonial persistido no cofre local (#119, sobre o schema de persistência da #180).
+ *
+ * ## Convenção monetária
+ * Valores monetários usam `Long` em centavos (nunca `Double`) — convenção herdada de `valorCentavos`,
+ * já estabelecida pela #180. `precoMedioCentavos` segue a mesma convenção. `quantidadeMilesimos`
+ * representa quantidade (ex.: número de cotas/ações, inclusive fracionário) como `Long` escalado
+ * por 1000 (3 casas decimais) — não é valor monetário, mas usa a mesma técnica de escalonamento
+ * inteiro pelo mesmo motivo: evitar ponto flutuante em qualquer dado que participe de cálculo
+ * patrimonial. `quantidadeMilesimos * precoMedioCentavos / 1000` nunca é a fonte de verdade do
+ * valor do item — `valorCentavos` é; os dois campos opcionais são só registro informativo (issue
+ * #119: "o usuário pode controlar o item apenas pelo valor atual").
+ *
+ * ## Convenção de dívidas
+ * `DIVIDA` usa `valorCentavos` negativo ou zero — sinal negativo, não uma flag separada — para que
+ * a soma direta de `valorCentavos` de todos os itens não arquivados já seja o patrimônio líquido,
+ * sem lógica condicional por tipo no cálculo futuro (fora do escopo desta issue, mas a convenção
+ * é definida aqui para não quebrar quem vier a implementá-lo). Os demais tipos usam valor >= 0.
+ * [io.savro.domain.patrimonio.ValidadorItemPatrimonial] aplica essa regra na criação/edição.
+ *
+ * ## Arquivamento e origem
+ * `arquivado` remove o item da visão padrão de Home/Patrimônio sem excluí-lo (issue: "arquivar" é
+ * operação distinta de "excluir"). `origem` e `atualizadoEmEpocaMs` juntos respondem "de onde veio
+ * e quando foi a última vez que esse valor mudou" — obrigatório pela issue ("manter origem manual
+ * e data da última atualização em cada item/ajuste").
  */
 data class ItemPatrimonial(
     val id: String,
     val tipo: TipoItemPatrimonial,
     val nome: String,
     val valorCentavos: Long,
+    val moeda: String,
     val instituicao: String?,
     val observacao: String?,
+    val quantidadeMilesimos: Long?,
+    val precoMedioCentavos: Long?,
+    val origem: OrigemValor,
+    val arquivado: Boolean,
     val criadoEmEpocaMs: Long,
     val atualizadoEmEpocaMs: Long,
+)
+
+/**
+ * Registro histórico de um ajuste manual de valor (issue #119: "registrar ajuste manual de valor
+ * preservando data e origem"). Cada ajuste é imutável e append-only — nunca é editado nem
+ * removido; só o item aponta seu `valorCentavos`/`atualizadoEmEpocaMs` atuais para o ajuste mais
+ * recente. `valorCentavosAnterior` permite reconstruir a linha do tempo de valor de um item sem
+ * depender de nenhum outro registro.
+ */
+data class AjusteValorItem(
+    val id: String,
+    val itemId: String,
+    val valorCentavosAnterior: Long,
+    val valorCentavosNovo: Long,
+    val origem: OrigemValor,
+    val dataEpocaMs: Long,
 )
 
 /** Metadados técnicos do banco local — não é um relatório de patrimônio, é estado de infra. */

--- a/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/FakeRepositorioItensPatrimoniais.kt
+++ b/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/FakeRepositorioItensPatrimoniais.kt
@@ -4,6 +4,7 @@ import io.savro.common.Resultado
 import io.savro.domain.patrimonio.ErroRepositorio
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
+import io.savro.model.AjusteValorItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
 
@@ -50,6 +51,15 @@ class FakeRepositorioItensPatrimoniais(
         Resultado.Sucesso(null)
 
     override suspend fun listarTodos(): Resultado<List<ItemPatrimonial>, ErroRepositorio> =
+        Resultado.Sucesso(emptyList())
+
+    override suspend fun registrarAjusteDeValor(
+        itemId: String,
+        novoValorCentavos: Long,
+        dataEpocaMs: Long,
+    ): Resultado<ItemPatrimonial, ErroRepositorio> = Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(itemId))
+
+    override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
         Resultado.Sucesso(emptyList())
 
     override suspend fun executarEmTransacao(

--- a/aplicativo/shared/domain/patrimonio/build.gradle.kts
+++ b/aplicativo/shared/domain/patrimonio/build.gradle.kts
@@ -14,9 +14,11 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":shared:core:common"))
             implementation(project(":shared:core:model"))
+            implementation(libs.kotlinx.coroutines.core)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ConversorMonetario.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ConversorMonetario.kt
@@ -1,0 +1,58 @@
+package io.savro.domain.patrimonio
+
+/**
+ * Conversão texto digitado <-> inteiro escalado, sem `Double`/`Float` em nenhum ponto (regra da
+ * issue #119: "valores monetários nunca usam Double"). Aceita `,` ou `.` como separador decimal —
+ * o último separador encontrado é tratado como decimal, os demais como separador de milhar e
+ * descartados; qualquer outro caractere não numérico também é descartado.
+ */
+object ConversorMonetario {
+
+    /** Texto do usuário -> centavos. `null` se o texto não contiver nenhum dígito. */
+    fun paraCentavos(texto: String): Long? = paraInteiroEscalado(texto, casasDecimais = 2)
+
+    /** Centavos -> texto com separador decimal `.` (a tela formata exibição/moeda por cima). */
+    fun centavosParaTexto(centavos: Long): String = inteiroEscaladoParaTexto(centavos, casasDecimais = 2)
+
+    /** Texto do usuário -> quantidade escalada por 1000 (3 casas decimais). `null` se vazio/inválido. */
+    fun paraQuantidadeMilesimos(texto: String): Long? = paraInteiroEscalado(texto, casasDecimais = 3)
+
+    fun quantidadeMilesimosParaTexto(milesimos: Long): String = inteiroEscaladoParaTexto(milesimos, casasDecimais = 3)
+
+    private fun paraInteiroEscalado(textoOriginal: String, casasDecimais: Int): Long? {
+        val texto = textoOriginal.trim()
+        if (texto.isEmpty()) return null
+
+        val negativo = texto.startsWith("-")
+        val semSinal = if (negativo) texto.substring(1) else texto
+
+        val indiceSeparador = semSinal.indexOfLast { it == ',' || it == '.' }
+        val parteInteira: String
+        val parteDecimal: String
+        if (indiceSeparador == -1) {
+            parteInteira = semSinal.filter { it.isDigit() }
+            parteDecimal = ""
+        } else {
+            parteInteira = semSinal.substring(0, indiceSeparador).filter { it.isDigit() }
+            parteDecimal = semSinal.substring(indiceSeparador + 1).filter { it.isDigit() }
+        }
+
+        if (parteInteira.isEmpty() && parteDecimal.isEmpty()) return null
+
+        val decimaisNormalizadas = parteDecimal.padEnd(casasDecimais, '0').take(casasDecimais)
+        val inteiroNormalizado = parteInteira.ifEmpty { "0" }
+        val digitosCombinados = (inteiroNormalizado + decimaisNormalizadas).trimStart('0').ifEmpty { "0" }
+        val valorAbsoluto = digitosCombinados.toLongOrNull() ?: return null
+
+        return if (negativo) -valorAbsoluto else valorAbsoluto
+    }
+
+    private fun inteiroEscaladoParaTexto(valor: Long, casasDecimais: Int): String {
+        val negativo = valor < 0
+        val absoluto = if (negativo) (-valor) else valor
+        val texto = absoluto.toString().padStart(casasDecimais + 1, '0')
+        val parteInteira = texto.dropLast(casasDecimais)
+        val parteDecimal = texto.takeLast(casasDecimais)
+        return (if (negativo) "-" else "") + parteInteira + "." + parteDecimal
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ErroValidacaoItem.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ErroValidacaoItem.kt
@@ -1,0 +1,29 @@
+package io.savro.domain.patrimonio
+
+/**
+ * Vocabulário de erro de validação de formulário (issue #119). Independente de UI — a tela só
+ * traduz cada caso para uma mensagem visível; a regra em si vive aqui, testável em `commonTest`
+ * sem Compose.
+ */
+sealed class ErroValidacaoItem {
+    data object NomeObrigatorio : ErroValidacaoItem()
+    data object NomeMuitoLongo : ErroValidacaoItem()
+    data object MoedaObrigatoria : ErroValidacaoItem()
+    data object MoedaInvalida : ErroValidacaoItem()
+    data object ValorObrigatorio : ErroValidacaoItem()
+
+    /** [tipo] não aceita valor negativo (todos exceto `DIVIDA`, ver convenção em `ItemPatrimonial`). */
+    data class ValorNaoPodeSerNegativo(val tipo: io.savro.model.TipoItemPatrimonial) : ErroValidacaoItem()
+
+    /** `DIVIDA` deve ser <= 0 — ver convenção de sinal em `ItemPatrimonial`. */
+    data object ValorDeDividaDeveSerNegativoOuZero : ErroValidacaoItem()
+
+    data object QuantidadeDeveSerPositiva : ErroValidacaoItem()
+    data object PrecoMedioDeveSerPositivo : ErroValidacaoItem()
+
+    /** Quantidade e preço médio só se aplicam a `RENDA_VARIAVEL` (issue #119). */
+    data object QuantidadeOuPrecoMedioForaDeContexto : ErroValidacaoItem()
+
+    data object ObservacaoMuitoLonga : ErroValidacaoItem()
+    data object InstituicaoMuitoLonga : ErroValidacaoItem()
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/EstadoFormularioItemPatrimonial.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/EstadoFormularioItemPatrimonial.kt
@@ -1,0 +1,138 @@
+package io.savro.domain.patrimonio
+
+import io.savro.model.TipoItemPatrimonial
+
+/** Campo do formulário de item patrimonial — usado para decidir o que pedir por tipo (issue #119). */
+enum class CampoFormularioItem {
+    TIPO,
+    NOME,
+    VALOR,
+    MOEDA,
+    INSTITUICAO,
+    OBSERVACAO,
+    QUANTIDADE,
+    PRECO_MEDIO,
+}
+
+/**
+ * Estado do formulário de criação/edição de item patrimonial (issue #119), 100% em `commonMain` —
+ * regra de negócio e estado de formulário não pertencem à camada de UI de nenhuma plataforma.
+ * Campos monetários ficam como texto bruto digitado pelo usuário; a conversão para os tipos
+ * inteiros escalados (`ConversorMonetario`) só acontece na validação, para que o campo de texto
+ * possa representar estados intermediários inválidos (ex.: "12,") sem perder o que o usuário
+ * digitou.
+ */
+data class EstadoFormularioItemPatrimonial(
+    val itemIdEmEdicao: String? = null,
+    val tipo: TipoItemPatrimonial? = null,
+    val nome: String = "",
+    val valorTexto: String = "",
+    val moeda: String = "BRL",
+    val instituicao: String = "",
+    val observacao: String = "",
+    val quantidadeTexto: String = "",
+    val precoMedioTexto: String = "",
+) {
+    val estaEditando: Boolean get() = itemIdEmEdicao != null
+
+    /**
+     * Campos visíveis para o [tipo] atual (issue #119: "solicitar somente campos necessários para
+     * o tipo selecionado"). Sem `tipo` escolhido, só o seletor de tipo é pedido. Quantidade/preço
+     * médio só aparecem em `RENDA_VARIAVEL`, e mesmo lá são opcionais — nunca obrigatórios (o
+     * usuário pode controlar o item só pelo valor atual).
+     */
+    fun camposVisiveis(): Set<CampoFormularioItem> {
+        if (tipo == null) return setOf(CampoFormularioItem.TIPO)
+        val base = mutableSetOf(
+            CampoFormularioItem.TIPO,
+            CampoFormularioItem.NOME,
+            CampoFormularioItem.VALOR,
+            CampoFormularioItem.MOEDA,
+            CampoFormularioItem.INSTITUICAO,
+            CampoFormularioItem.OBSERVACAO,
+        )
+        if (tipo == TipoItemPatrimonial.RENDA_VARIAVEL) {
+            base += CampoFormularioItem.QUANTIDADE
+            base += CampoFormularioItem.PRECO_MEDIO
+        }
+        return base
+    }
+
+    fun camposObrigatorios(): Set<CampoFormularioItem> = setOf(
+        CampoFormularioItem.TIPO,
+        CampoFormularioItem.NOME,
+        CampoFormularioItem.VALOR,
+        CampoFormularioItem.MOEDA,
+    )
+}
+
+/**
+ * Serialização estável do rascunho de formulário para preservação de lifecycle (issue #119:
+ * "preservar formulário durante transições previstas de Android e iOS"). Cada campo vira uma
+ * linha `chave:tamanho:valor` (formato "length-prefixed", sem dependência de biblioteca de
+ * serialização e sem caractere delimitador que possa colidir com o texto digitado pelo usuário) —
+ * cada plataforma guarda essa string onde fizer sentido (`SavedStateHandle`/Bundle no Android,
+ * mecanismo equivalente de restauração de cena no iOS; a implementação do adapter é
+ * responsabilidade de cada host, este arquivo só define o contrato comum, testável sem nenhuma
+ * API de plataforma). Campos vazios não são escritos; um rascunho totalmente vazio serializa para
+ * string vazia.
+ */
+object RascunhoFormularioItem {
+
+    private val PADRAO = EstadoFormularioItemPatrimonial()
+
+    fun serializar(estado: EstadoFormularioItemPatrimonial): String {
+        val campos = linkedMapOf(
+            "itemIdEmEdicao" to estado.itemIdEmEdicao.orEmpty(),
+            "tipo" to (estado.tipo?.name.orEmpty()),
+            "nome" to estado.nome,
+            "valorTexto" to estado.valorTexto,
+            // Só grava 'moeda' quando o usuário mudou do padrão — senão um formulário intocado
+            // (nada digitado ainda) já não serializaria para string vazia.
+            "moeda" to estado.moeda.takeIf { it != PADRAO.moeda }.orEmpty(),
+            "instituicao" to estado.instituicao,
+            "observacao" to estado.observacao,
+            "quantidadeTexto" to estado.quantidadeTexto,
+            "precoMedioTexto" to estado.precoMedioTexto,
+        )
+        return campos
+            .filterValues { it.isNotEmpty() }
+            .entries
+            .joinToString(separator = "") { (chave, valor) -> "$chave:${valor.length}:$valor" }
+    }
+
+    fun restaurar(rascunho: String): EstadoFormularioItemPatrimonial {
+        if (rascunho.isEmpty()) return EstadoFormularioItemPatrimonial()
+
+        val campos = mutableMapOf<String, String>()
+        var posicao = 0
+        while (posicao < rascunho.length) {
+            val fimChave = rascunho.indexOf(':', posicao)
+            if (fimChave == -1) break
+            val chave = rascunho.substring(posicao, fimChave)
+
+            val fimTamanho = rascunho.indexOf(':', fimChave + 1)
+            if (fimTamanho == -1) break
+            val tamanho = rascunho.substring(fimChave + 1, fimTamanho).toIntOrNull() ?: break
+
+            val inicioValor = fimTamanho + 1
+            val fimValor = inicioValor + tamanho
+            if (fimValor > rascunho.length) break
+            campos[chave] = rascunho.substring(inicioValor, fimValor)
+            posicao = fimValor
+        }
+
+        return EstadoFormularioItemPatrimonial(
+            itemIdEmEdicao = campos["itemIdEmEdicao"]?.takeIf { it.isNotEmpty() },
+            tipo = campos["tipo"]?.takeIf { it.isNotEmpty() }
+                ?.let { runCatching { TipoItemPatrimonial.valueOf(it) }.getOrNull() },
+            nome = campos["nome"].orEmpty(),
+            valorTexto = campos["valorTexto"].orEmpty(),
+            moeda = campos["moeda"]?.takeIf { it.isNotEmpty() } ?: "BRL",
+            instituicao = campos["instituicao"].orEmpty(),
+            observacao = campos["observacao"].orEmpty(),
+            quantidadeTexto = campos["quantidadeTexto"].orEmpty(),
+            precoMedioTexto = campos["precoMedioTexto"].orEmpty(),
+        )
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/FiltroItensPatrimoniais.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/FiltroItensPatrimoniais.kt
@@ -1,0 +1,30 @@
+package io.savro.domain.patrimonio
+
+import io.savro.model.ItemPatrimonial
+import io.savro.model.TipoItemPatrimonial
+
+/**
+ * Filtro aplicado sobre itens já carregados do banco local (issue #119: "buscar e filtrar apenas
+ * dados já armazenados localmente" — nunca consulta remota). `incluirArquivados = false` é o
+ * padrão: a visão principal de Home/Patrimônio não mostra itens arquivados a menos que a tela
+ * peça explicitamente.
+ */
+data class FiltroItensPatrimoniais(
+    val texto: String = "",
+    val tipos: Set<TipoItemPatrimonial> = emptySet(),
+    val incluirArquivados: Boolean = false,
+) {
+    fun aplicar(itens: List<ItemPatrimonial>): List<ItemPatrimonial> {
+        val textoNormalizado = texto.trim().lowercase()
+        return itens.filter { item ->
+            (incluirArquivados || !item.arquivado) &&
+                (tipos.isEmpty() || item.tipo in tipos) &&
+                (textoNormalizado.isEmpty() || correspondeAoTexto(item, textoNormalizado))
+        }
+    }
+
+    private fun correspondeAoTexto(item: ItemPatrimonial, textoNormalizado: String): Boolean =
+        item.nome.lowercase().contains(textoNormalizado) ||
+            item.instituicao?.lowercase()?.contains(textoNormalizado) == true ||
+            item.observacao?.lowercase()?.contains(textoNormalizado) == true
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/GeradorIdItem.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/GeradorIdItem.kt
@@ -1,0 +1,14 @@
+package io.savro.domain.patrimonio
+
+import kotlin.random.Random
+
+/**
+ * Identificador local aleatório (128 bits, hexadecimal) para itens e ajustes patrimoniais. Não
+ * depende de nenhuma API de plataforma (`kotlin.random.Random` é stdlib comum) — dispensa uma
+ * dependência de UUID só para gerar uma chave primária local que nunca precisa ser globalmente
+ * única fora do dispositivo do usuário.
+ */
+object GeradorIdItem {
+    fun novoId(): String = (1..4)
+        .joinToString("") { Random.nextInt(0, 0x10000).toString(16).padStart(4, '0') }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/RepositorioItensPatrimoniais.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/RepositorioItensPatrimoniais.kt
@@ -1,6 +1,7 @@
 package io.savro.domain.patrimonio
 
 import io.savro.common.Resultado
+import io.savro.model.AjusteValorItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
 
@@ -38,6 +39,21 @@ interface RepositorioItensPatrimoniais {
     suspend fun buscarPorId(id: String): Resultado<ItemPatrimonial?, ErroRepositorio>
 
     suspend fun listarTodos(): Resultado<List<ItemPatrimonial>, ErroRepositorio>
+
+    /**
+     * Aplica um ajuste manual de valor atomicamente (issue #119): grava o novo `valorCentavos` no
+     * item **e** o registro histórico em [AjusteValorItem] na mesma operação — nunca um sem o
+     * outro. Implementações fazem isso internamente com a mesma garantia de
+     * [executarEmTransacao] (tudo ou nada); o chamador não precisa orquestrar a transação.
+     */
+    suspend fun registrarAjusteDeValor(
+        itemId: String,
+        novoValorCentavos: Long,
+        dataEpocaMs: Long,
+    ): Resultado<ItemPatrimonial, ErroRepositorio>
+
+    /** Histórico de ajustes de um item, do mais antigo para o mais recente. */
+    suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio>
 
     /**
      * Executa [bloco] atomicamente: todas as operações de dentro se aplicam juntas, ou nenhuma se

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ServicoPatrimonio.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ServicoPatrimonio.kt
@@ -1,0 +1,222 @@
+package io.savro.domain.patrimonio
+
+import io.savro.common.Relogio
+import io.savro.common.Resultado
+import io.savro.model.ItemPatrimonial
+import io.savro.model.OrigemValor
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** Erro de operação de patrimônio — validação de formulário ou falha de persistência, nunca os dois misturados. */
+sealed class ErroServicoPatrimonio {
+    data class ValidacaoFalhou(val erros: List<ErroValidacaoItem>) : ErroServicoPatrimonio()
+    data class Persistencia(val erro: ErroRepositorio) : ErroServicoPatrimonio()
+    data object ItemNaoEncontrado : ErroServicoPatrimonio()
+}
+
+/**
+ * Orquestra as operações de cadastro manual de patrimônio (issue #119) sobre
+ * [RepositorioItensPatrimoniais] e expõe [itens] como estado reativo único — Home e Patrimônio
+ * observam a mesma instância deste serviço (via composição do host, `:shared:app`) e por isso se
+ * atualizam imediatamente após qualquer alteração, sem chamada explícita de "recarregar tela"
+ * (issue: "atualizar Home e Patrimônio imediatamente após qualquer alteração").
+ *
+ * Cada operação de escrita recarrega [itens] a partir do repositório ao final — a fonte de
+ * verdade nunca é o cache em memória, é o banco; o cache só existe para não recarregar
+ * silenciosamente em toda leitura de tela.
+ */
+class ServicoPatrimonio(
+    private val repositorio: RepositorioItensPatrimoniais,
+    private val relogio: Relogio,
+) {
+    private val mutexRecarga = Mutex()
+    private val _itens = MutableStateFlow<List<ItemPatrimonial>>(emptyList())
+    val itens: StateFlow<List<ItemPatrimonial>> = _itens.asStateFlow()
+
+    /** Deve ser chamado depois de [RepositorioItensPatrimoniais.abrir] pelo host. */
+    suspend fun carregar(): Resultado<List<ItemPatrimonial>, ErroServicoPatrimonio> =
+        recarregar()
+
+    fun buscarEFiltrar(filtro: FiltroItensPatrimoniais): List<ItemPatrimonial> =
+        filtro.aplicar(_itens.value)
+
+    suspend fun criar(
+        estado: EstadoFormularioItemPatrimonial,
+    ): Resultado<ItemPatrimonial, ErroServicoPatrimonio> {
+        val validado = when (val resultado = ValidadorItemPatrimonial.validar(estado)) {
+            is Resultado.Falha -> return Resultado.Falha(ErroServicoPatrimonio.ValidacaoFalhou(resultado.erro))
+            is Resultado.Sucesso -> resultado.valor
+        }
+
+        val agora = relogio.agoraEmEpocaMs()
+        val item = ItemPatrimonial(
+            id = GeradorIdItem.novoId(),
+            tipo = validado.tipo,
+            nome = validado.nome,
+            valorCentavos = validado.valorCentavos,
+            moeda = validado.moeda,
+            instituicao = validado.instituicao,
+            observacao = validado.observacao,
+            quantidadeMilesimos = validado.quantidadeMilesimos,
+            precoMedioCentavos = validado.precoMedioCentavos,
+            origem = OrigemValor.MANUAL,
+            arquivado = false,
+            criadoEmEpocaMs = agora,
+            atualizadoEmEpocaMs = agora,
+        )
+
+        return when (val resultado = repositorio.inserir(item)) {
+            is Resultado.Falha -> Resultado.Falha(ErroServicoPatrimonio.Persistencia(resultado.erro))
+            is Resultado.Sucesso -> {
+                recarregar()
+                Resultado.Sucesso(resultado.valor)
+            }
+        }
+    }
+
+    suspend fun editar(
+        estado: EstadoFormularioItemPatrimonial,
+    ): Resultado<ItemPatrimonial, ErroServicoPatrimonio> {
+        val id = estado.itemIdEmEdicao ?: return Resultado.Falha(ErroServicoPatrimonio.ItemNaoEncontrado)
+        val existente = _itens.value.firstOrNull { it.id == id }
+            ?: return Resultado.Falha(ErroServicoPatrimonio.ItemNaoEncontrado)
+
+        val validado = when (val resultado = ValidadorItemPatrimonial.validar(estado)) {
+            is Resultado.Falha -> return Resultado.Falha(ErroServicoPatrimonio.ValidacaoFalhou(resultado.erro))
+            is Resultado.Sucesso -> resultado.valor
+        }
+
+        val itemAtualizado = existente.copy(
+            tipo = validado.tipo,
+            nome = validado.nome,
+            valorCentavos = validado.valorCentavos,
+            moeda = validado.moeda,
+            instituicao = validado.instituicao,
+            observacao = validado.observacao,
+            quantidadeMilesimos = validado.quantidadeMilesimos,
+            precoMedioCentavos = validado.precoMedioCentavos,
+        )
+
+        return when (val resultado = repositorio.atualizar(itemAtualizado)) {
+            is Resultado.Falha -> Resultado.Falha(mapearErroDeAtualizacao(resultado.erro))
+            is Resultado.Sucesso -> {
+                recarregar()
+                Resultado.Sucesso(resultado.valor)
+            }
+        }
+    }
+
+    /** Duplica um item existente como um novo item independente (issue #119: operação "duplicar"). */
+    suspend fun duplicar(id: String): Resultado<ItemPatrimonial, ErroServicoPatrimonio> {
+        val original = _itens.value.firstOrNull { it.id == id }
+            ?: return Resultado.Falha(ErroServicoPatrimonio.ItemNaoEncontrado)
+
+        val agora = relogio.agoraEmEpocaMs()
+        val copia = original.copy(
+            id = GeradorIdItem.novoId(),
+            nome = nomeDeCopia(original.nome),
+            arquivado = false,
+            criadoEmEpocaMs = agora,
+            atualizadoEmEpocaMs = agora,
+        )
+
+        return when (val resultado = repositorio.inserir(copia)) {
+            is Resultado.Falha -> Resultado.Falha(ErroServicoPatrimonio.Persistencia(resultado.erro))
+            is Resultado.Sucesso -> {
+                recarregar()
+                Resultado.Sucesso(resultado.valor)
+            }
+        }
+    }
+
+    /** Arquiva ou desarquiva (issue #119: "arquivar" é reversível, distinto de "excluir"). */
+    suspend fun arquivar(id: String, arquivado: Boolean): Resultado<ItemPatrimonial, ErroServicoPatrimonio> {
+        val existente = _itens.value.firstOrNull { it.id == id }
+            ?: return Resultado.Falha(ErroServicoPatrimonio.ItemNaoEncontrado)
+        if (existente.arquivado == arquivado) return Resultado.Sucesso(existente)
+
+        return when (val resultado = repositorio.atualizar(existente.copy(arquivado = arquivado))) {
+            is Resultado.Falha -> Resultado.Falha(mapearErroDeAtualizacao(resultado.erro))
+            is Resultado.Sucesso -> {
+                recarregar()
+                Resultado.Sucesso(resultado.valor)
+            }
+        }
+    }
+
+    suspend fun excluir(id: String): Resultado<Unit, ErroServicoPatrimonio> =
+        when (val resultado = repositorio.excluir(id)) {
+            is Resultado.Falha -> Resultado.Falha(mapearErroDeAtualizacao(resultado.erro))
+            is Resultado.Sucesso -> {
+                recarregar()
+                Resultado.Sucesso(Unit)
+            }
+        }
+
+    /**
+     * Ajuste manual de valor (issue #119: "registrar ajuste manual de valor preservando data e
+     * origem"). Delega ao repositório, que grava o novo valor no item e o registro histórico
+     * atomicamente — nenhuma chance de um sem o outro.
+     */
+    suspend fun ajustarValor(
+        id: String,
+        novoValorTexto: String,
+    ): Resultado<ItemPatrimonial, ErroServicoPatrimonio> {
+        val existente = _itens.value.firstOrNull { it.id == id }
+            ?: return Resultado.Falha(ErroServicoPatrimonio.ItemNaoEncontrado)
+
+        val novoValorCentavos = ConversorMonetario.paraCentavos(novoValorTexto)
+            ?: return Resultado.Falha(ErroServicoPatrimonio.ValidacaoFalhou(listOf(ErroValidacaoItem.ValorObrigatorio)))
+
+        if (existente.tipo == io.savro.model.TipoItemPatrimonial.DIVIDA && novoValorCentavos > 0) {
+            return Resultado.Falha(
+                ErroServicoPatrimonio.ValidacaoFalhou(listOf(ErroValidacaoItem.ValorDeDividaDeveSerNegativoOuZero)),
+            )
+        }
+        if (existente.tipo != io.savro.model.TipoItemPatrimonial.DIVIDA && novoValorCentavos < 0) {
+            return Resultado.Falha(
+                ErroServicoPatrimonio.ValidacaoFalhou(listOf(ErroValidacaoItem.ValorNaoPodeSerNegativo(existente.tipo))),
+            )
+        }
+
+        val resultado = repositorio.registrarAjusteDeValor(
+            itemId = id,
+            novoValorCentavos = novoValorCentavos,
+            dataEpocaMs = relogio.agoraEmEpocaMs(),
+        )
+        return when (resultado) {
+            is Resultado.Falha -> Resultado.Falha(mapearErroDeAtualizacao(resultado.erro))
+            is Resultado.Sucesso -> {
+                recarregar()
+                Resultado.Sucesso(resultado.valor)
+            }
+        }
+    }
+
+    suspend fun listarAjustes(id: String) = repositorio.listarAjustesDeValor(id)
+
+    private suspend fun recarregar(): Resultado<List<ItemPatrimonial>, ErroServicoPatrimonio> = mutexRecarga.withLock {
+        when (val resultado = repositorio.listarTodos()) {
+            is Resultado.Falha -> Resultado.Falha(ErroServicoPatrimonio.Persistencia(resultado.erro))
+            is Resultado.Sucesso -> {
+                _itens.value = resultado.valor
+                Resultado.Sucesso(resultado.valor)
+            }
+        }
+    }
+
+    private fun mapearErroDeAtualizacao(erro: ErroRepositorio): ErroServicoPatrimonio =
+        if (erro is ErroRepositorio.ItemNaoEncontrado) {
+            ErroServicoPatrimonio.ItemNaoEncontrado
+        } else {
+            ErroServicoPatrimonio.Persistencia(erro)
+        }
+
+    private fun nomeDeCopia(nomeOriginal: String): String {
+        val sufixo = " (cópia)"
+        return if (nomeOriginal.endsWith(sufixo)) "$nomeOriginal 2" else "$nomeOriginal$sufixo"
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ValidadorItemPatrimonial.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ValidadorItemPatrimonial.kt
@@ -1,0 +1,136 @@
+package io.savro.domain.patrimonio
+
+import io.savro.common.Resultado
+import io.savro.model.OrigemValor
+import io.savro.model.TipoItemPatrimonial
+
+private const val TAMANHO_MAXIMO_NOME = 120
+private const val TAMANHO_MAXIMO_INSTITUICAO = 120
+private const val TAMANHO_MAXIMO_OBSERVACAO = 500
+private val PADRAO_MOEDA = Regex("^[A-Z]{3}$")
+
+/** Campos já validados e prontos para virar [io.savro.model.ItemPatrimonial] (falta só id/timestamps/origem/arquivado). */
+data class ItemPatrimonialValidado(
+    val tipo: TipoItemPatrimonial,
+    val nome: String,
+    val valorCentavos: Long,
+    val moeda: String,
+    val instituicao: String?,
+    val observacao: String?,
+    val quantidadeMilesimos: Long?,
+    val precoMedioCentavos: Long?,
+)
+
+/**
+ * Valida [EstadoFormularioItemPatrimonial] segundo as regras obrigatórias da issue #119. Pura,
+ * sem acesso a banco/rede/relógio — só recebe e devolve dados. Retorna todos os erros encontrados
+ * de uma vez (não para no primeiro), para a tela poder sinalizar todos os campos inválidos juntos.
+ */
+object ValidadorItemPatrimonial {
+
+    fun validar(estado: EstadoFormularioItemPatrimonial): Resultado<ItemPatrimonialValidado, List<ErroValidacaoItem>> {
+        val erros = mutableListOf<ErroValidacaoItem>()
+
+        val tipo = estado.tipo
+        val nome = estado.nome.trim()
+        if (nome.isEmpty()) erros += ErroValidacaoItem.NomeObrigatorio
+        if (nome.length > TAMANHO_MAXIMO_NOME) erros += ErroValidacaoItem.NomeMuitoLongo
+
+        val moeda = estado.moeda.trim().uppercase()
+        if (moeda.isEmpty()) {
+            erros += ErroValidacaoItem.MoedaObrigatoria
+        } else if (!PADRAO_MOEDA.matches(moeda)) {
+            erros += ErroValidacaoItem.MoedaInvalida
+        }
+
+        val valorCentavos = ConversorMonetario.paraCentavos(estado.valorTexto)
+        if (valorCentavos == null) {
+            erros += ErroValidacaoItem.ValorObrigatorio
+        } else if (tipo != null) {
+            if (tipo == TipoItemPatrimonial.DIVIDA && valorCentavos > 0) {
+                erros += ErroValidacaoItem.ValorDeDividaDeveSerNegativoOuZero
+            }
+            if (tipo != TipoItemPatrimonial.DIVIDA && valorCentavos < 0) {
+                erros += ErroValidacaoItem.ValorNaoPodeSerNegativo(tipo)
+            }
+        }
+
+        val instituicao = estado.instituicao.trim().ifEmpty { null }
+        if ((instituicao?.length ?: 0) > TAMANHO_MAXIMO_INSTITUICAO) erros += ErroValidacaoItem.InstituicaoMuitoLonga
+
+        val observacao = estado.observacao.trim().ifEmpty { null }
+        if ((observacao?.length ?: 0) > TAMANHO_MAXIMO_OBSERVACAO) erros += ErroValidacaoItem.ObservacaoMuitoLonga
+
+        val quantidadeInformada = estado.quantidadeTexto.isNotBlank()
+        val precoMedioInformado = estado.precoMedioTexto.isNotBlank()
+        var quantidadeMilesimos: Long? = null
+        var precoMedioCentavos: Long? = null
+
+        if (quantidadeInformada || precoMedioInformado) {
+            if (tipo != TipoItemPatrimonial.RENDA_VARIAVEL) {
+                erros += ErroValidacaoItem.QuantidadeOuPrecoMedioForaDeContexto
+            }
+            if (quantidadeInformada) {
+                quantidadeMilesimos = ConversorMonetario.paraQuantidadeMilesimos(estado.quantidadeTexto)
+                if (quantidadeMilesimos == null || quantidadeMilesimos <= 0) {
+                    erros += ErroValidacaoItem.QuantidadeDeveSerPositiva
+                    quantidadeMilesimos = null
+                }
+            }
+            if (precoMedioInformado) {
+                precoMedioCentavos = ConversorMonetario.paraCentavos(estado.precoMedioTexto)
+                if (precoMedioCentavos == null || precoMedioCentavos <= 0) {
+                    erros += ErroValidacaoItem.PrecoMedioDeveSerPositivo
+                    precoMedioCentavos = null
+                }
+            }
+        }
+
+        if (tipo == null || erros.isNotEmpty() || valorCentavos == null) {
+            return Resultado.Falha(erros.ifEmpty { listOf(ErroValidacaoItem.ValorObrigatorio) })
+        }
+
+        return Resultado.Sucesso(
+            ItemPatrimonialValidado(
+                tipo = tipo,
+                nome = nome,
+                valorCentavos = valorCentavos,
+                moeda = moeda,
+                instituicao = instituicao,
+                observacao = observacao,
+                quantidadeMilesimos = quantidadeMilesimos,
+                precoMedioCentavos = precoMedioCentavos,
+            ),
+        )
+    }
+}
+
+/**
+ * Resumo revisável antes de salvar (issue #119: "mostrar resumo revisável antes de salvar").
+ * Só formata o que [ValidadorItemPatrimonial] já validou — nunca formata um estado inválido.
+ */
+data class ResumoItemPatrimonial(
+    val tipo: TipoItemPatrimonial,
+    val nome: String,
+    val valorFormatado: String,
+    val moeda: String,
+    val instituicao: String?,
+    val observacao: String?,
+    val quantidadeFormatada: String?,
+    val precoMedioFormatado: String?,
+    val origem: OrigemValor,
+) {
+    companion object {
+        fun de(item: ItemPatrimonialValidado): ResumoItemPatrimonial = ResumoItemPatrimonial(
+            tipo = item.tipo,
+            nome = item.nome,
+            valorFormatado = ConversorMonetario.centavosParaTexto(item.valorCentavos),
+            moeda = item.moeda,
+            instituicao = item.instituicao,
+            observacao = item.observacao,
+            quantidadeFormatada = item.quantidadeMilesimos?.let(ConversorMonetario::quantidadeMilesimosParaTexto),
+            precoMedioFormatado = item.precoMedioCentavos?.let(ConversorMonetario::centavosParaTexto),
+            origem = OrigemValor.MANUAL,
+        )
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ConversorMonetarioTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ConversorMonetarioTest.kt
@@ -1,0 +1,53 @@
+package io.savro.domain.patrimonio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ConversorMonetarioTest {
+
+    @Test
+    fun paraCentavos_aceitaVirgulaComoDecimal() {
+        assertEquals(123_456L, ConversorMonetario.paraCentavos("1234,56"))
+    }
+
+    @Test
+    fun paraCentavos_aceitaPontoComoDecimal() {
+        assertEquals(123_456L, ConversorMonetario.paraCentavos("1234.56"))
+    }
+
+    @Test
+    fun paraCentavos_aceitaSomenteInteiro() {
+        assertEquals(100_000L, ConversorMonetario.paraCentavos("1000"))
+    }
+
+    @Test
+    fun paraCentavos_aceitaSeparadorDeMilharENegativo() {
+        assertEquals(-1_234_567L, ConversorMonetario.paraCentavos("-12.345,67"))
+    }
+
+    @Test
+    fun paraCentavos_textoVazio_retornaNulo() {
+        assertNull(ConversorMonetario.paraCentavos(""))
+        assertNull(ConversorMonetario.paraCentavos("   "))
+    }
+
+    @Test
+    fun paraCentavos_semDigitos_retornaNulo() {
+        assertNull(ConversorMonetario.paraCentavos(",-."))
+    }
+
+    @Test
+    fun centavosParaTexto_eDeVoltaSaoConsistentes() {
+        val original = 1_234_567L
+        val texto = ConversorMonetario.centavosParaTexto(original)
+        assertEquals("12345.67", texto)
+        assertEquals(original, ConversorMonetario.paraCentavos(texto))
+    }
+
+    @Test
+    fun paraQuantidadeMilesimos_aceitaTresCasasDecimais() {
+        assertEquals(1_500L, ConversorMonetario.paraQuantidadeMilesimos("1,5"))
+        assertEquals(1_234L, ConversorMonetario.paraQuantidadeMilesimos("1,234"))
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/EstadoFormularioItemPatrimonialTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/EstadoFormularioItemPatrimonialTest.kt
@@ -1,0 +1,69 @@
+package io.savro.domain.patrimonio
+
+import io.savro.model.TipoItemPatrimonial
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EstadoFormularioItemPatrimonialTest {
+
+    @Test
+    fun semTipo_soMostraCampoDeTipo() {
+        val estado = EstadoFormularioItemPatrimonial()
+        assertEquals(setOf(CampoFormularioItem.TIPO), estado.camposVisiveis())
+    }
+
+    @Test
+    fun contaCorrente_naoMostraQuantidadeNemPrecoMedio() {
+        val estado = EstadoFormularioItemPatrimonial(tipo = TipoItemPatrimonial.CONTA)
+        assertFalse(CampoFormularioItem.QUANTIDADE in estado.camposVisiveis())
+        assertFalse(CampoFormularioItem.PRECO_MEDIO in estado.camposVisiveis())
+    }
+
+    @Test
+    fun rendaVariavel_mostraQuantidadeEPrecoMedioComoNaoObrigatorios() {
+        val estado = EstadoFormularioItemPatrimonial(tipo = TipoItemPatrimonial.RENDA_VARIAVEL)
+        assertTrue(CampoFormularioItem.QUANTIDADE in estado.camposVisiveis())
+        assertTrue(CampoFormularioItem.PRECO_MEDIO in estado.camposVisiveis())
+        assertFalse(CampoFormularioItem.QUANTIDADE in estado.camposObrigatorios())
+        assertFalse(CampoFormularioItem.PRECO_MEDIO in estado.camposObrigatorios())
+    }
+
+    // Issue #119: "preservar formulário durante transições previstas de Android e iOS" — a base
+    // testável em commonMain é essa serialização/restauração ser idempotente e sem perda de dado.
+    @Test
+    fun rascunho_serializarERestaurar_reproduzOMesmoEstado() {
+        val original = EstadoFormularioItemPatrimonial(
+            itemIdEmEdicao = "item-42",
+            tipo = TipoItemPatrimonial.RENDA_VARIAVEL,
+            nome = "Tesouro Selic",
+            valorTexto = "1.234,56",
+            moeda = "BRL",
+            instituicao = "Corretora X",
+            observacao = "Reserva de emergência",
+            quantidadeTexto = "10",
+            precoMedioTexto = "100,00",
+        )
+
+        val restaurado = RascunhoFormularioItem.restaurar(RascunhoFormularioItem.serializar(original))
+
+        assertEquals(original, restaurado)
+    }
+
+    @Test
+    fun rascunho_comCaracteresEspeciais_naoQuebraOParser() {
+        val original = EstadoFormularioItemPatrimonial(
+            nome = "Nota: contém : dois pontos e \"aspas\"",
+            observacao = "linha 1\nlinha 2",
+        )
+        val restaurado = RascunhoFormularioItem.restaurar(RascunhoFormularioItem.serializar(original))
+        assertEquals(original, restaurado)
+    }
+
+    @Test
+    fun rascunho_estadoVazio_serializaParaStringVazia() {
+        assertEquals("", RascunhoFormularioItem.serializar(EstadoFormularioItemPatrimonial()))
+        assertEquals(EstadoFormularioItemPatrimonial(), RascunhoFormularioItem.restaurar(""))
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/FakeRepositorioItensPatrimoniaisSimples.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/FakeRepositorioItensPatrimoniaisSimples.kt
@@ -1,0 +1,88 @@
+package io.savro.domain.patrimonio
+
+import io.savro.common.Relogio
+import io.savro.common.Resultado
+import io.savro.model.AjusteValorItem
+import io.savro.model.ItemPatrimonial
+import io.savro.model.MetadadosBancoLocal
+
+/**
+ * Fake mínimo para testar [ServicoPatrimonio] sem depender de `:shared:core:database` (que
+ * depende de `:shared:domain:patrimonio`, não o contrário — ver ADR-002). Não simula
+ * abrir()/chave/transação de verdade: cobre só o que `ServicoPatrimonio` de fato chama. O
+ * comportamento de engine real (Room/SQLCipher) é coberto pelo contrato compartilhado em
+ * `:shared:core:database` (`RepositorioItensPatrimoniaisContratoTeste`).
+ */
+class FakeRepositorioItensPatrimoniaisSimples(
+    private val relogio: Relogio,
+    /** Se != null, toda operação de escrita falha com este erro — simula falha de persistência. */
+    var falhaSimulada: ErroRepositorio? = null,
+) : RepositorioItensPatrimoniais {
+
+    private val itens = LinkedHashMap<String, ItemPatrimonial>()
+    private val ajustes = mutableListOf<AjusteValorItem>()
+
+    override suspend fun abrir(): Resultado<MetadadosBancoLocal, ErroRepositorio> =
+        Resultado.Sucesso(MetadadosBancoLocal(1, itens.size))
+
+    override suspend fun fechar() = Unit
+
+    override suspend fun inserir(item: ItemPatrimonial): Resultado<ItemPatrimonial, ErroRepositorio> {
+        falhaSimulada?.let { return Resultado.Falha(it) }
+        itens[item.id] = item
+        return Resultado.Sucesso(item)
+    }
+
+    override suspend fun atualizar(item: ItemPatrimonial): Resultado<ItemPatrimonial, ErroRepositorio> {
+        falhaSimulada?.let { return Resultado.Falha(it) }
+        if (!itens.containsKey(item.id)) return Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(item.id))
+        itens[item.id] = item
+        return Resultado.Sucesso(item)
+    }
+
+    override suspend fun excluir(id: String): Resultado<Unit, ErroRepositorio> {
+        falhaSimulada?.let { return Resultado.Falha(it) }
+        if (itens.remove(id) == null) return Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(id))
+        return Resultado.Sucesso(Unit)
+    }
+
+    override suspend fun buscarPorId(id: String): Resultado<ItemPatrimonial?, ErroRepositorio> =
+        Resultado.Sucesso(itens[id])
+
+    override suspend fun listarTodos(): Resultado<List<ItemPatrimonial>, ErroRepositorio> =
+        Resultado.Sucesso(itens.values.toList())
+
+    override suspend fun registrarAjusteDeValor(
+        itemId: String,
+        novoValorCentavos: Long,
+        dataEpocaMs: Long,
+    ): Resultado<ItemPatrimonial, ErroRepositorio> {
+        falhaSimulada?.let { return Resultado.Falha(it) }
+        val existente = itens[itemId] ?: return Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(itemId))
+        ajustes += AjusteValorItem(
+            id = GeradorIdItem.novoId(),
+            itemId = itemId,
+            valorCentavosAnterior = existente.valorCentavos,
+            valorCentavosNovo = novoValorCentavos,
+            origem = existente.origem,
+            dataEpocaMs = dataEpocaMs,
+        )
+        val atualizado = existente.copy(valorCentavos = novoValorCentavos, atualizadoEmEpocaMs = dataEpocaMs)
+        itens[itemId] = atualizado
+        return Resultado.Sucesso(atualizado)
+    }
+
+    override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
+        Resultado.Sucesso(ajustes.filter { it.itemId == itemId })
+
+    override suspend fun executarEmTransacao(
+        bloco: suspend TransacaoItensPatrimoniais.() -> Unit,
+    ): Resultado<Unit, ErroRepositorio> = Resultado.Sucesso(Unit)
+}
+
+class RelogioDeTesteSimples(private var agora: Long = 1_000L) : Relogio {
+    override fun agoraEmEpocaMs(): Long = agora
+    fun avancar(ms: Long) {
+        agora += ms
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/FiltroItensPatrimoniaisTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/FiltroItensPatrimoniaisTest.kt
@@ -1,0 +1,66 @@
+package io.savro.domain.patrimonio
+
+import io.savro.model.ItemPatrimonial
+import io.savro.model.OrigemValor
+import io.savro.model.TipoItemPatrimonial
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FiltroItensPatrimoniaisTest {
+
+    private fun item(
+        id: String,
+        nome: String,
+        tipo: TipoItemPatrimonial = TipoItemPatrimonial.CONTA,
+        arquivado: Boolean = false,
+        instituicao: String? = null,
+    ) = ItemPatrimonial(
+        id = id,
+        tipo = tipo,
+        nome = nome,
+        valorCentavos = 1,
+        moeda = "BRL",
+        instituicao = instituicao,
+        observacao = null,
+        quantidadeMilesimos = null,
+        precoMedioCentavos = null,
+        origem = OrigemValor.MANUAL,
+        arquivado = arquivado,
+        criadoEmEpocaMs = 1,
+        atualizadoEmEpocaMs = 1,
+    )
+
+    @Test
+    fun semFiltro_omiteArquivadosPorPadrao() {
+        val itens = listOf(item("1", "Conta"), item("2", "Conta arquivada", arquivado = true))
+        val resultado = FiltroItensPatrimoniais().aplicar(itens)
+        assertEquals(listOf("1"), resultado.map { it.id })
+    }
+
+    @Test
+    fun incluirArquivados_mostraTodos() {
+        val itens = listOf(item("1", "Conta"), item("2", "Conta arquivada", arquivado = true))
+        val resultado = FiltroItensPatrimoniais(incluirArquivados = true).aplicar(itens)
+        assertEquals(setOf("1", "2"), resultado.map { it.id }.toSet())
+    }
+
+    @Test
+    fun filtroPorTipo_retornaSoOTipoEscolhido() {
+        val itens = listOf(
+            item("1", "Conta", tipo = TipoItemPatrimonial.CONTA),
+            item("2", "Ações", tipo = TipoItemPatrimonial.RENDA_VARIAVEL),
+        )
+        val resultado = FiltroItensPatrimoniais(tipos = setOf(TipoItemPatrimonial.RENDA_VARIAVEL)).aplicar(itens)
+        assertEquals(listOf("2"), resultado.map { it.id })
+    }
+
+    @Test
+    fun buscaPorTexto_casaNomeInstituicaoOuObservacao_semDiferenciarMaiusculas() {
+        val itens = listOf(
+            item("1", "Conta Nubank", instituicao = "Nubank"),
+            item("2", "Poupança", instituicao = "Banco do Brasil"),
+        )
+        val resultado = FiltroItensPatrimoniais(texto = "nubank").aplicar(itens)
+        assertEquals(listOf("1"), resultado.map { it.id })
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ServicoPatrimonioTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ServicoPatrimonioTest.kt
@@ -1,0 +1,169 @@
+package io.savro.domain.patrimonio
+
+import io.savro.common.Resultado
+import io.savro.model.TipoItemPatrimonial
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ServicoPatrimonioTest {
+
+    private fun novoServico(
+        relogio: RelogioDeTesteSimples = RelogioDeTesteSimples(),
+        repositorio: FakeRepositorioItensPatrimoniaisSimples = FakeRepositorioItensPatrimoniaisSimples(relogio),
+    ) = Triple(ServicoPatrimonio(repositorio, relogio), repositorio, relogio)
+
+    private fun estadoConta(nome: String = "Conta corrente", valor: String = "1000,00") =
+        EstadoFormularioItemPatrimonial(tipo = TipoItemPatrimonial.CONTA, nome = nome, valorTexto = valor, moeda = "BRL")
+
+    @Test
+    fun criar_comFormularioValido_persisteEAtualizaEstadoReativo() = runTest {
+        val (servico, _, _) = novoServico()
+
+        val resultado = servico.criar(estadoConta())
+        assertIs<Resultado.Sucesso<*>>(resultado)
+
+        // "atualizar Home e Patrimônio imediatamente" — o StateFlow reflete a escrita sem chamada
+        // explícita de recarregar por quem observa.
+        assertEquals(1, servico.itens.value.size)
+        assertEquals("Conta corrente", servico.itens.value.single().nome)
+    }
+
+    @Test
+    fun criar_comFormularioInvalido_naoPersisteNadaERetornaErrosDeValidacao() = runTest {
+        val (servico, _, _) = novoServico()
+
+        val resultado = servico.criar(estadoConta(nome = ""))
+        assertIs<Resultado.Falha<ErroServicoPatrimonio.ValidacaoFalhou>>(resultado)
+        assertTrue(ErroValidacaoItem.NomeObrigatorio in resultado.erro.erros)
+        assertEquals(0, servico.itens.value.size)
+    }
+
+    @Test
+    fun criar_comFalhaDePersistencia_naoDeixaItemParcialNoEstadoReativo() = runTest {
+        val relogio = RelogioDeTesteSimples()
+        val repositorio = FakeRepositorioItensPatrimoniaisSimples(relogio)
+        val (servico, _, _) = novoServico(relogio, repositorio)
+
+        repositorio.falhaSimulada = ErroRepositorio.FalhaTransacao("disco cheio")
+        val resultado = servico.criar(estadoConta())
+
+        assertIs<Resultado.Falha<ErroServicoPatrimonio.Persistencia>>(resultado)
+        assertEquals(0, servico.itens.value.size)
+    }
+
+    @Test
+    fun editar_alteraCamposEMantemId() = runTest {
+        val (servico, _, _) = novoServico()
+        val criado = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        val editado = servico.editar(
+            estadoConta(nome = "Conta poupança", valor = "2000,00").copy(itemIdEmEdicao = criado.id),
+        )
+        assertIs<Resultado.Sucesso<*>>(editado)
+        assertEquals("Conta poupança", servico.itens.value.single().nome)
+        assertEquals(criado.id, servico.itens.value.single().id)
+        assertEquals(200_000L, servico.itens.value.single().valorCentavos)
+    }
+
+    @Test
+    fun editar_itemInexistente_retornaItemNaoEncontrado() = runTest {
+        val (servico, _, _) = novoServico()
+        val resultado = servico.editar(estadoConta().copy(itemIdEmEdicao = "nao-existe"))
+        assertIs<Resultado.Falha<ErroServicoPatrimonio.ItemNaoEncontrado>>(resultado)
+    }
+
+    @Test
+    fun duplicar_criaNovoItemIndependenteComNomeDistinto() = runTest {
+        val (servico, _, _) = novoServico()
+        val original = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        val duplicado = servico.duplicar(original.id)
+        assertIs<Resultado.Sucesso<*>>(duplicado)
+        assertEquals(2, servico.itens.value.size)
+        assertTrue(servico.itens.value.any { it.id != original.id && it.nome.contains("cópia") })
+    }
+
+    @Test
+    fun arquivar_removeDaListagemPadraoMasMantemNoBanco() = runTest {
+        val (servico, _, _) = novoServico()
+        val item = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        val arquivado = servico.arquivar(item.id, arquivado = true)
+        assertIs<Resultado.Sucesso<*>>(arquivado)
+
+        val visiveis = servico.buscarEFiltrar(FiltroItensPatrimoniais())
+        assertEquals(0, visiveis.size)
+
+        val comArquivados = servico.buscarEFiltrar(FiltroItensPatrimoniais(incluirArquivados = true))
+        assertEquals(1, comArquivados.size)
+    }
+
+    @Test
+    fun excluir_removePermanentementeEAtualizaEstadoReativo() = runTest {
+        val (servico, _, _) = novoServico()
+        val item = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        val resultado = servico.excluir(item.id)
+        assertIs<Resultado.Sucesso<Unit>>(resultado)
+        assertEquals(0, servico.itens.value.size)
+    }
+
+    @Test
+    fun ajustarValor_preservaDataEOrigemDoAjuste() = runTest {
+        val relogio = RelogioDeTesteSimples(agora = 5_000L)
+        val repositorio = FakeRepositorioItensPatrimoniaisSimples(relogio)
+        val (servico, repo, rel) = novoServico(relogio, repositorio)
+        val item = (servico.criar(estadoConta(valor = "1000,00")) as Resultado.Sucesso).valor
+
+        rel.avancar(1_000)
+        val resultado = servico.ajustarValor(item.id, "1.500,00")
+        assertIs<Resultado.Sucesso<*>>(resultado)
+        assertEquals(150_000L, servico.itens.value.single().valorCentavos)
+        assertEquals(6_000L, servico.itens.value.single().atualizadoEmEpocaMs)
+
+        val ajustes = (repo.listarAjustesDeValor(item.id) as Resultado.Sucesso).valor
+        assertEquals(1, ajustes.size)
+        assertEquals(100_000L, ajustes.single().valorCentavosAnterior)
+        assertEquals(150_000L, ajustes.single().valorCentavosNovo)
+        assertEquals(6_000L, ajustes.single().dataEpocaMs)
+    }
+
+    @Test
+    fun ajustarValor_dividaComValorPositivo_eRejeitado() = runTest {
+        val (servico, _, _) = novoServico()
+        val estadoDivida = EstadoFormularioItemPatrimonial(
+            tipo = TipoItemPatrimonial.DIVIDA,
+            nome = "Cartão de crédito",
+            valorTexto = "-500,00",
+            moeda = "BRL",
+        )
+        val item = (servico.criar(estadoDivida) as Resultado.Sucesso).valor
+
+        val resultado = servico.ajustarValor(item.id, "500,00")
+        assertIs<Resultado.Falha<ErroServicoPatrimonio.ValidacaoFalhou>>(resultado)
+        assertEquals(-50_000L, servico.itens.value.single().valorCentavos)
+    }
+
+    @Test
+    fun buscarEFiltrar_combinaTextoETipo() = runTest {
+        val (servico, _, _) = novoServico()
+        servico.criar(estadoConta(nome = "Conta Nubank"))
+        servico.criar(
+            EstadoFormularioItemPatrimonial(
+                tipo = TipoItemPatrimonial.RENDA_VARIAVEL,
+                nome = "Ações Nubank",
+                valorTexto = "500,00",
+                moeda = "BRL",
+            ),
+        )
+
+        val resultado = servico.buscarEFiltrar(
+            FiltroItensPatrimoniais(texto = "nubank", tipos = setOf(TipoItemPatrimonial.RENDA_VARIAVEL)),
+        )
+        assertEquals(1, resultado.size)
+        assertEquals("Ações Nubank", resultado.single().nome)
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ValidadorItemPatrimonialTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ValidadorItemPatrimonialTest.kt
@@ -1,0 +1,110 @@
+package io.savro.domain.patrimonio
+
+import io.savro.common.Resultado
+import io.savro.model.TipoItemPatrimonial
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class ValidadorItemPatrimonialTest {
+
+    private fun estadoValido(
+        tipo: TipoItemPatrimonial = TipoItemPatrimonial.CONTA,
+        valorTexto: String = "1000,00",
+    ) = EstadoFormularioItemPatrimonial(tipo = tipo, nome = "Conta corrente", valorTexto = valorTexto, moeda = "BRL")
+
+    @Test
+    fun estadoValido_retornaSucesso() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido())
+        assertIs<Resultado.Sucesso<ItemPatrimonialValidado>>(resultado)
+        assertEquals(100_000L, resultado.valor.valorCentavos)
+    }
+
+    @Test
+    fun nomeEmBranco_retornaNomeObrigatorio() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido().copy(nome = "  "))
+        assertIs<Resultado.Falha<List<ErroValidacaoItem>>>(resultado)
+        assertTrue(ErroValidacaoItem.NomeObrigatorio in resultado.erro)
+    }
+
+    @Test
+    fun semTipo_retornaFalha() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido().copy(tipo = null))
+        assertIs<Resultado.Falha<List<ErroValidacaoItem>>>(resultado)
+    }
+
+    @Test
+    fun valorEmBranco_retornaValorObrigatorio() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido(valorTexto = ""))
+        assertIs<Resultado.Falha<List<ErroValidacaoItem>>>(resultado)
+        assertTrue(ErroValidacaoItem.ValorObrigatorio in resultado.erro)
+    }
+
+    @Test
+    fun moedaInvalida_retornaMoedaInvalida() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido().copy(moeda = "R$"))
+        assertIs<Resultado.Falha<List<ErroValidacaoItem>>>(resultado)
+        assertTrue(ErroValidacaoItem.MoedaInvalida in resultado.erro)
+    }
+
+    @Test
+    fun divida_comValorPositivo_retornaErroDeSinal() {
+        val resultado = ValidadorItemPatrimonial.validar(
+            estadoValido(tipo = TipoItemPatrimonial.DIVIDA, valorTexto = "500,00"),
+        )
+        assertIs<Resultado.Falha<List<ErroValidacaoItem>>>(resultado)
+        assertTrue(ErroValidacaoItem.ValorDeDividaDeveSerNegativoOuZero in resultado.erro)
+    }
+
+    @Test
+    fun divida_comValorNegativo_ehValida() {
+        val resultado = ValidadorItemPatrimonial.validar(
+            estadoValido(tipo = TipoItemPatrimonial.DIVIDA, valorTexto = "-500,00"),
+        )
+        assertIs<Resultado.Sucesso<ItemPatrimonialValidado>>(resultado)
+        assertEquals(-50_000L, resultado.valor.valorCentavos)
+    }
+
+    @Test
+    fun tipoNaoDivida_comValorNegativo_retornaErro() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido(valorTexto = "-1,00"))
+        assertIs<Resultado.Falha<List<ErroValidacaoItem>>>(resultado)
+        assertTrue(resultado.erro.any { it is ErroValidacaoItem.ValorNaoPodeSerNegativo })
+    }
+
+    @Test
+    fun rendaVariavel_semQuantidadeNemPrecoMedio_ehValida() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido(tipo = TipoItemPatrimonial.RENDA_VARIAVEL))
+        assertIs<Resultado.Sucesso<ItemPatrimonialValidado>>(resultado)
+    }
+
+    @Test
+    fun rendaVariavel_comQuantidadeEPrecoMedio_calculaCamposOpcionais() {
+        val estado = estadoValido(tipo = TipoItemPatrimonial.RENDA_VARIAVEL).copy(
+            quantidadeTexto = "10",
+            precoMedioTexto = "25,50",
+        )
+        val resultado = ValidadorItemPatrimonial.validar(estado)
+        assertIs<Resultado.Sucesso<ItemPatrimonialValidado>>(resultado)
+        assertEquals(10_000L, resultado.valor.quantidadeMilesimos)
+        assertEquals(2_550L, resultado.valor.precoMedioCentavos)
+    }
+
+    @Test
+    fun quantidadeInformada_foraDeRendaVariavel_retornaErroDeContexto() {
+        val estado = estadoValido(tipo = TipoItemPatrimonial.CONTA).copy(quantidadeTexto = "10")
+        val resultado = ValidadorItemPatrimonial.validar(estado)
+        assertIs<Resultado.Falha<List<ErroValidacaoItem>>>(resultado)
+        assertTrue(ErroValidacaoItem.QuantidadeOuPrecoMedioForaDeContexto in resultado.erro)
+    }
+
+    @Test
+    fun resumo_formataItemValidadoParaRevisao() {
+        val resultado = ValidadorItemPatrimonial.validar(estadoValido())
+        assertIs<Resultado.Sucesso<ItemPatrimonialValidado>>(resultado)
+        val resumo = ResumoItemPatrimonial.de(resultado.valor)
+        assertEquals("1000.00", resumo.valorFormatado)
+        assertEquals("Conta corrente", resumo.nome)
+    }
+}

--- a/documentacao/arquitetura/validacoes/119-cadastro-manual-patrimonio.md
+++ b/documentacao/arquitetura/validacoes/119-cadastro-manual-patrimonio.md
@@ -1,0 +1,70 @@
+# 119 — Cadastro manual e manutenção de itens patrimoniais
+
+Registro de decisões tomadas na implementação da issue #119, sobre a fundação de persistência
+cifrada da #180 (`6423288`) e do cofre da #211/#118 (`1e97b09`).
+
+## Taxonomia de tipos
+
+`TipoItemPatrimonial` (schema v3) substitui os cinco valores mínimos da #180
+(`CONTA`/`INVESTIMENTO`/`IMOVEL`/`VEICULO`/`OUTRO`, documentados ali como "suficiente para provar
+persistência cifrada ponta a ponta", não como taxonomia final) pelos sete tipos do MVP1: `CONTA`,
+`RENDA_VARIAVEL`, `RENDA_FIXA`, `CRIPTO`, `BEM`, `DIVIDA`, `OUTRO`. `INVESTIMENTO -> RENDA_VARIAVEL`
+e `IMOVEL`/`VEICULO -> BEM` são remapeados por migration (`MIGRATION_2_3` no Android,
+equivalente em `RepositorioItensPatrimoniaisSQLCipher.aplicarSchemaEMigrations` no iOS) — nenhum
+dado existente é perdido.
+
+## Convenção monetária
+
+`Long` em centavos, nunca `Double` — convenção já estabelecida por `valorCentavos` na #180, mantida
+e estendida a `precoMedioCentavos`. `quantidadeMilesimos` usa a mesma técnica (inteiro escalado,
+aqui por 1000 — 3 casas decimais) para quantidade fracionária de cotas/ações, apesar de não ser
+valor monetário, pelo mesmo motivo: nenhum cálculo patrimonial passa por ponto flutuante.
+Conversão texto digitado <-> inteiro escalado fica em `ConversorMonetario`
+(`shared/domain/patrimonio`), sem `Double`/`Float` em nenhum ponto.
+
+## Convenção de dívidas
+
+`DIVIDA` usa `valorCentavos` negativo ou zero — sinal, não uma coluna/flag separada — para que o
+cálculo futuro de patrimônio líquido (fora do escopo desta issue) seja só a soma de
+`valorCentavos` de todos os itens não arquivados, sem lógica condicional por tipo. Os demais tipos
+exigem valor >= 0. `ValidadorItemPatrimonial` aplica essa regra na criação, edição e ajuste manual
+de valor.
+
+## Ajuste manual de valor e origem
+
+Novo agregado `AjusteValorItem` (tabela `ajustes_valor_item`, FK `ON DELETE CASCADE` para
+`itens_patrimoniais`) é um histórico append-only: cada ajuste grava valor anterior, valor novo,
+origem e data — nunca é editado nem removido. `RepositorioItensPatrimoniais.registrarAjusteDeValor`
+grava o novo valor no item **e** o registro histórico atomicamente (mesma transação); a issue exige
+que "falha ao salvar não crie item parcial" e isso vale igualmente para o ajuste.
+
+`OrigemValor` só tem `MANUAL` hoje — existe como enum explícito (não um literal implícito
+espalhado pelo código) para o dia em que #124/#125 (catálogo/cotação) introduzirem outra origem.
+
+## Estado de formulário e preservação de lifecycle
+
+Regras de formulário (campos obrigatórios por tipo, validação, resumo revisável) vivem 100% em
+`commonMain` (`EstadoFormularioItemPatrimonial`, `ValidadorItemPatrimonial`,
+`ResumoItemPatrimonial`). Preservação de formulário em background/retorno usa
+`RascunhoFormularioItem.serializar`/`restaurar` (formato "length-prefixed", sem caractere
+delimitador que colida com texto digitado) através de `rememberSaveable` em
+`shared/app/PatrimonioScreens.kt`.
+
+`rememberSaveable` em Compose Multiplatform depende do host registrar um `SaveableStateRegistry`
+que sobreviva à transição de lifecycle relevante — Android já resolve isso via
+`ComponentActivity`/`SavedStateRegistry` nativos. A garantia equivalente para cenas iOS (o app
+volta do background ou o sistema recria o `UIViewController`) é responsabilidade do adapter
+`iosMain`, entregue por Igor nesta issue — ver PR para o que foi validado no runner macOS.
+
+## Estado reativo compartilhado (Home/Patrimônio)
+
+`ServicoPatrimonio` (`shared/domain/patrimonio`) expõe `itens: StateFlow<List<ItemPatrimonial>>` e
+recarrega a partir do repositório ao final de toda operação de escrita. Home e Patrimônio (#120,
+fora do escopo aqui) observam a mesma instância — nenhuma tela precisa de um evento explícito de
+"recarregar". A tela de patrimônio implementada nesta issue (`TelaPatrimonio` em
+`shared/app/PatrimonioScreens.kt`) já consome esse padrão como primeiro caso real.
+
+## Fora do escopo desta issue (confirmado)
+
+CSV/XLSX/OFX (#199), catálogo e cotações (#124/#125), integração bancária/Open Finance/B3, múltiplas
+carteiras, Home definitiva com gráficos (#120) — nada disso foi implementado.


### PR DESCRIPTION
## Objetivo

Closes #119

Cadastro manual e manutencao de itens patrimoniais em Android e iOS (Compose Multiplatform), sobre a persistencia cifrada da #180 e o cofre da #211/#118. Rascunho aberto como draft -- ver observacoes de validacao abaixo antes do merge.

## Solucao aplicada

- Schema local (v2 -> v3) estendido para os 7 tipos do MVP1 (CONTA, RENDA_VARIAVEL, RENDA_FIXA, CRIPTO, BEM, DIVIDA, OUTRO), com moeda, quantidade/preco medio opcionais (renda variavel), origem e arquivamento. Migration remapeia dados existentes da #180 (INVESTIMENTO -> RENDA_VARIAVEL, IMOVEL/VEICULO -> BEM) no Android (Room) e no iOS (SQLCipher).
- Novo agregado `AjusteValorItem` (tabela `ajustes_valor_item`, append-only) para ajuste manual de valor preservando data e origem, gravado atomicamente com o novo valor do item.
- Regras de negocio e estado de formulario 100% em commonMain (`shared/domain/patrimonio`): `ServicoPatrimonio` (estado reativo `StateFlow` para Home/Patrimonio), `ValidadorItemPatrimonial`, `ConversorMonetario` (sem Double/Float), `EstadoFormularioItemPatrimonial`/`RascunhoFormularioItem` (preservacao de lifecycle).
- Tela `TelaPatrimonio` em Compose Multiplatform (`shared/app`) substitui o placeholder da Home deixado pela #118: criar, editar, duplicar, arquivar/desarquivar, excluir, ajustar valor, buscar e filtrar, com resumo revisavel antes de salvar. A mesma implementacao roda em Android e iOS.

## Convencoes definidas (ver `documentacao/arquitetura/validacoes/119-cadastro-manual-patrimonio.md`)

- Monetario: `Long` em centavos (convencao ja usada pela #180), nunca `Double`. Quantidade de renda variavel usa a mesma tecnica (inteiro escalado por 1000).
- Divida: `valorCentavos` negativo ou zero (sinal, nao flag separada) -- soma direta ja vira patrimonio liquido no futuro, sem condicional por tipo.

## Camadas afetadas

`shared/core/model`, `shared/core/database` (Android/Room + iOS/SQLCipher + commonTest), `shared/domain/patrimonio` (novo: casos de uso, validacao, estado de formulario), `shared/app` (nova tela), `androidApp` (wiring).

## Validacoes executadas

- Nao foi possivel rodar Gradle/Android SDK nem toolchain iOS neste ambiente (sem Android SDK local, sem macOS/Xcode) -- validacao real depende inteiramente da CI deste PR (`aplicativo-ci.yml`), como ja e pratica registrada neste repo para mudancas em `:shared:core:database` (ver comentarios em `RepositorioItensPatrimoniaisSQLCipher.kt`/`SQLiteCifrado.kt`).
- Revisão cuidadosa linha a linha do diff e dos testes contra os criterios de aceite da issue.
- Testes novos em commonTest cobrindo: validacao, criacao, edicao, duplicacao, arquivamento, exclusao, ajuste de valor (data/origem), busca e filtro, rollback em falha de persistencia, round-trip do rascunho de formulario -- rodam via `androidUnitTest` (Robolectric) e `iosSimulatorArm64Test` na CI.
- Migration 2->3 testada com um teste dedicado (`RoomMigrationTest`) que recria fisicamente um banco v2 e valida o remapeamento de tipo e os novos campos apos a migration real.

## Criterios de aceite (issue #119)

- [x] Um item simples pode ser cadastrado em poucos passos (Android e iOS -- mesma UI Compose Multiplatform).
- [x] Ativos, bens e dividas podem ser representados so pelo valor atual.
- [x] Criar, editar, duplicar, arquivar e excluir funcionam offline (nenhuma chamada de rede em nenhum ponto).
- [x] Alteracoes aparecem imediatamente na experiencia principal (StateFlow compartilhado).
- [x] Estado do formulario preservado via `rememberSaveable` + `RascunhoFormularioItem` -- adapter iOS revisado por Igor (ver commits seguintes).
- [x] Testes comuns cobrem validacao, criacao, edicao, arquivamento e exclusao (e mais: duplicacao, ajuste, busca/filtro, rollback).

## Riscos e limitacoes

- CI ainda nao confirmada verde neste ambiente -- iterando ate ficar verde antes de tirar do draft.
- Fora do escopo (conforme a issue): CSV/XLSX/OFX (#199), catalogo/cotacoes (#124/#125), integracao bancaria/Open Finance/B3, multiplas carteiras, Home definitiva com graficos (#120).