### PR TITLE
feat(aplicativo): experiência principal — Home, Patrimônio, Detalhe e timeline (#120)

### DIFF
--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreScreens.kt
@@ -141,10 +141,10 @@ private fun BotaoTentarNovamente(gerenciador: GerenciadorCofre) {
 }
 
 /**
- * Destino pós-onboarding/desbloqueio: cadastro manual de patrimônio (#119) é a experiência
- * principal do app hoje — Home/Patrimônio definitivas com gráficos e resumo consolidado são a
- * #120, fora do escopo aqui. Acesso a ativar/alterar/remover a proteção do cofre (#118) continua
- * disponível a partir daqui.
+ * Destino pós-onboarding/desbloqueio: [TelaPatrimonio] (em `PatrimonioScreens.kt`) hospeda a
+ * experiência principal completa (#120) — Home, Patrimônio e Detalhe, todos sobre a mesma
+ * instância de [servicoPatrimonio]. Acesso a ativar/alterar/remover a proteção do cofre (#118)
+ * continua disponível a partir daqui.
  */
 @Composable
 private fun TelaHome(gerenciador: GerenciadorCofre, servicoPatrimonio: ServicoPatrimonio) {

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/DetalheScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/DetalheScreens.kt
@@ -1,0 +1,200 @@
+package io.savro.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import io.savro.designsystem.componentes.SavroButton
+import io.savro.designsystem.componentes.SavroButtonStyle
+import io.savro.designsystem.componentes.SavroCard
+import io.savro.designsystem.componentes.SavroDivider
+import io.savro.designsystem.componentes.SavroState
+import io.savro.designsystem.componentes.SavroStatePanel
+import io.savro.designsystem.componentes.SavroText
+import io.savro.designsystem.componentes.SavroTextStyle
+import io.savro.designsystem.tema.SavroThemeTokens
+import io.savro.domain.patrimonio.ConversorMonetario
+import io.savro.domain.patrimonio.ServicoPatrimonio
+import io.savro.domain.patrimonio.calculo.ApresentacaoValor
+import io.savro.domain.patrimonio.calculo.FormatadorData
+import io.savro.model.EventoTimelineItem
+import io.savro.model.ItemPatrimonial
+import io.savro.model.TipoEventoTimeline
+import kotlinx.coroutines.launch
+
+/**
+ * Detalhe de um item patrimonial (issue #120): nome, classe, instituição, moeda, valor atual,
+ * valor investido/quantidade/preço médio quando existirem, data e origem da atualização,
+ * observações, ações (editar/ajustar valor/duplicar/arquivar/excluir) e a linha do tempo básica
+ * do item.
+ */
+@Composable
+internal fun TelaDetalheItem(
+    servico: ServicoPatrimonio,
+    itemId: String,
+    ocultarValores: Boolean,
+    aoVoltar: () -> Unit,
+    aoEditar: (String) -> Unit,
+    aoAjustarValor: (String) -> Unit,
+) {
+    val itens by servico.itens.collectAsState()
+    val item = itens.firstOrNull { it.id == itemId }
+    var timeline by remember(itemId) { mutableStateOf<List<EventoTimelineItem>>(emptyList()) }
+    val escopo = rememberCoroutineScope()
+
+    // Recarrega a timeline sempre que os itens mudam (CRUD/ajuste em qualquer tela) — a mesma
+    // reatividade via StateFlow que Home e Patrimônio usam, aplicada à linha do tempo deste item.
+    LaunchedEffect(itemId, itens) {
+        val resultado = servico.listarTimelineDoItem(itemId)
+        if (resultado is io.savro.common.Resultado.Sucesso) timeline = resultado.valor
+    }
+
+    if (item == null) {
+        SavroStatePanel(
+            state = SavroState.Empty,
+            title = "Item não encontrado",
+            message = "Este item pode ter sido excluído.",
+            action = { SavroButton(label = "Voltar", onClick = aoVoltar, loadingStateDescription = "") },
+        )
+        return
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.md),
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            SavroText(item.nome, style = SavroTextStyle.Headline)
+            SavroButton(label = "Voltar", onClick = aoVoltar, style = SavroButtonStyle.Secondary, loadingStateDescription = "")
+        }
+
+        SavroCard(modifier = Modifier.fillMaxWidth()) {
+            SavroText(rotuloDoTipo(item.tipo), style = SavroTextStyle.Label)
+            item.instituicao?.let { SavroText(it, style = SavroTextStyle.BodySmall) }
+            if (item.arquivado) SavroText("Arquivado", style = SavroTextStyle.Label)
+
+            SavroDivider(modifier = Modifier.padding(vertical = SavroThemeTokens.spacing.sm))
+
+            LinhaComOculto("Valor atual", "${formatarValor(item)} ${item.moeda}", ocultarValores)
+
+            valorInvestidoCentavos(item)?.let { valorInvestido ->
+                LinhaComOculto(
+                    "Valor investido",
+                    "${ConversorMonetario.centavosParaTexto(valorInvestido)} ${item.moeda}",
+                    ocultarValores,
+                )
+            }
+            item.quantidadeMilesimos?.let {
+                SavroText("Quantidade: ${ConversorMonetario.quantidadeMilesimosParaTexto(it)}", style = SavroTextStyle.BodySmall)
+            }
+            item.precoMedioCentavos?.let {
+                LinhaComOculto("Preço médio", "${ConversorMonetario.centavosParaTexto(it)} ${item.moeda}", ocultarValores)
+            }
+
+            SavroDivider(modifier = Modifier.padding(vertical = SavroThemeTokens.spacing.sm))
+
+            SavroText(
+                "Atualizado em ${FormatadorData.paraDataCurta(item.atualizadoEmEpocaMs)} · origem: ${rotuloDaOrigem(item.origem)}",
+                style = SavroTextStyle.BodySmall,
+            )
+            item.observacao?.takeIf { it.isNotBlank() }?.let {
+                SavroText(it, style = SavroTextStyle.BodySmall)
+            }
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+            SavroButton(label = "Editar", onClick = { aoEditar(item.id) }, style = SavroButtonStyle.Secondary, loadingStateDescription = "")
+            SavroButton(
+                label = "Ajustar valor",
+                onClick = { aoAjustarValor(item.id) },
+                style = SavroButtonStyle.Secondary,
+                loadingStateDescription = "",
+            )
+            SavroButton(
+                label = "Duplicar",
+                onClick = { escopo.launch { servico.duplicar(item.id); aoVoltar() } },
+                style = SavroButtonStyle.Secondary,
+                loadingStateDescription = "",
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+            SavroButton(
+                label = if (item.arquivado) "Reativar" else "Arquivar",
+                onClick = { escopo.launch { servico.arquivar(item.id, arquivado = !item.arquivado) } },
+                style = SavroButtonStyle.Secondary,
+                loadingStateDescription = "",
+            )
+            SavroButton(
+                label = "Excluir",
+                onClick = { escopo.launch { servico.excluir(item.id); aoVoltar() } },
+                style = SavroButtonStyle.Destructive,
+                loadingStateDescription = "",
+            )
+        }
+
+        SavroText("Linha do tempo", style = SavroTextStyle.Title)
+        if (timeline.isEmpty()) {
+            SavroText("Nenhum evento registrado ainda.", style = SavroTextStyle.BodySmall)
+        } else {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+                items(timeline, key = { it.id }) { evento ->
+                    SavroCard(modifier = Modifier.fillMaxWidth()) {
+                        SavroText(rotuloDoEvento(evento.tipo), style = SavroTextStyle.Body)
+                        SavroText(FormatadorData.paraDataCurta(evento.dataEpocaMs), style = SavroTextStyle.BodySmall)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LinhaComOculto(rotulo: String, valorFormatado: String, oculto: Boolean) {
+    val texto = ApresentacaoValor.texto(valorFormatado, oculto)
+    val descricao = ApresentacaoValor.descricaoAcessibilidade("$rotulo: $valorFormatado", oculto)
+    Row(
+        modifier = Modifier.fillMaxWidth().semantics { contentDescription = descricao },
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        SavroText(rotulo, style = SavroTextStyle.Body)
+        SavroText(texto, style = SavroTextStyle.Body)
+    }
+}
+
+/**
+ * `quantidadeMilesimos` (escalado x1000) * `precoMedioCentavos` / 1000 — sempre informativo, nunca
+ * a fonte de verdade do valor do item (ver javadoc de [ItemPatrimonial]). `null` se algum dos dois
+ * campos opcionais não existir.
+ */
+private fun valorInvestidoCentavos(item: ItemPatrimonial): Long? {
+    val quantidade = item.quantidadeMilesimos ?: return null
+    val precoMedio = item.precoMedioCentavos ?: return null
+    return quantidade * precoMedio / 1000
+}
+
+private fun rotuloDaOrigem(origem: io.savro.model.OrigemValor): String = when (origem) {
+    io.savro.model.OrigemValor.MANUAL -> "manual"
+}
+
+private fun rotuloDoEvento(tipo: TipoEventoTimeline): String = when (tipo) {
+    TipoEventoTimeline.ITEM_CRIADO -> "Item criado"
+    TipoEventoTimeline.VALOR_AJUSTADO -> "Valor ajustado"
+    TipoEventoTimeline.ITEM_EDITADO -> "Item editado"
+    TipoEventoTimeline.ITEM_ARQUIVADO -> "Item arquivado"
+    TipoEventoTimeline.ITEM_REATIVADO -> "Item reativado"
+}

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/HomeScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/HomeScreens.kt
@@ -1,0 +1,172 @@
+package io.savro.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import io.savro.designsystem.componentes.SavroButton
+import io.savro.designsystem.componentes.SavroButtonStyle
+import io.savro.designsystem.componentes.SavroCard
+import io.savro.designsystem.componentes.SavroCardTone
+import io.savro.designsystem.componentes.SavroDivider
+import io.savro.designsystem.componentes.SavroState
+import io.savro.designsystem.componentes.SavroStatePanel
+import io.savro.designsystem.componentes.SavroText
+import io.savro.designsystem.componentes.SavroTextStyle
+import io.savro.designsystem.tema.SavroThemeTokens
+import io.savro.domain.patrimonio.ConversorMonetario
+import io.savro.domain.patrimonio.ServicoPatrimonio
+import io.savro.domain.patrimonio.calculo.ApresentacaoValor
+import io.savro.domain.patrimonio.calculo.CalculoPatrimonio
+import io.savro.domain.patrimonio.calculo.FormatadorData
+
+/**
+ * Home (issue #120): patrimônio bruto, dívidas, patrimônio líquido, distribuição básica por
+ * classe, data da última atualização, itens que precisam de atualização e a ação principal de
+ * adicionar item. Usa exatamente [CalculoPatrimonio] — o mesmo motor de cálculo consumido por
+ * Patrimônio e Detalhe (nenhuma soma/porcentagem é recalculada de outra forma aqui).
+ */
+@Composable
+internal fun TelaHomeResumo(
+    servico: ServicoPatrimonio,
+    ocultarValores: Boolean,
+    aoAlternarOcultarValores: () -> Unit,
+    aoCriar: () -> Unit,
+    aoAbrirItem: (String) -> Unit,
+) {
+    val itens by servico.itens.collectAsState()
+    val resumo = remember(itens) { CalculoPatrimonio.resumo(itens) }
+    val distribuicoes = remember(itens) { CalculoPatrimonio.distribuicaoPorClasse(itens) }
+    val dataUltimaAtualizacao = remember(itens) { CalculoPatrimonio.dataUltimaAtualizacao(itens) }
+    val itensDesatualizados = remember(itens) {
+        CalculoPatrimonio.itensQuePrecisamAtualizacao(itens, agoraEpocaMs = servico.agoraEmEpocaMs())
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.md),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            SavroText("Home", style = SavroTextStyle.Headline)
+            SavroButton(
+                label = if (ocultarValores) "Mostrar valores" else "Ocultar valores",
+                onClick = aoAlternarOcultarValores,
+                style = SavroButtonStyle.Secondary,
+                loadingStateDescription = "",
+            )
+        }
+
+        if (itens.isEmpty()) {
+            SavroStatePanel(
+                state = SavroState.Empty,
+                title = "Sem patrimônio cadastrado ainda",
+                message = "Adicione o primeiro item para ver seu patrimônio consolidado.",
+                action = { BotaoAdicionarItem(aoCriar) },
+            )
+            return
+        }
+
+        if (!resumo.consolidavel) {
+            SavroStatePanel(
+                state = SavroState.Offline,
+                title = "Totais não consolidados",
+                message = "Há itens em moedas diferentes — cada moeda aparece separada abaixo.",
+            )
+        }
+
+        resumo.totaisPorMoeda.forEach { total ->
+            SavroCard(modifier = Modifier.fillMaxWidth()) {
+                if (!resumo.consolidavel) SavroText(total.moeda, style = SavroTextStyle.Label)
+                LinhaValor("Patrimônio bruto", total.brutoCentavos, total.moeda, ocultarValores)
+                LinhaValor("Dívidas", total.dividasCentavos, total.moeda, ocultarValores)
+                SavroDivider(modifier = Modifier.padding(vertical = SavroThemeTokens.spacing.sm))
+                LinhaValor("Patrimônio líquido", total.liquidoCentavos, total.moeda, ocultarValores, destaque = true)
+            }
+        }
+
+        SavroButton(
+            label = "Adicionar item",
+            onClick = aoCriar,
+            modifier = Modifier.fillMaxWidth(),
+            loadingStateDescription = "",
+        )
+
+        dataUltimaAtualizacao?.let {
+            SavroText(
+                "Última atualização: ${FormatadorData.paraDataCurta(it)}",
+                style = SavroTextStyle.BodySmall,
+            )
+        }
+
+        if (distribuicoes.isNotEmpty()) {
+            SavroText("Distribuição por classe", style = SavroTextStyle.Title)
+            distribuicoes.forEach { distribuicao ->
+                SavroCard(modifier = Modifier.fillMaxWidth()) {
+                    if (!resumo.consolidavel) SavroText(distribuicao.moeda, style = SavroTextStyle.Label)
+                    distribuicao.fatias.forEach { fatia ->
+                        SavroText(
+                            "${rotuloDoTipo(fatia.tipo)} — ${fatia.percentualBasisPoints / 100}%",
+                            style = SavroTextStyle.BodySmall,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (itensDesatualizados.isNotEmpty()) {
+            SavroText("Itens que precisam de atualização", style = SavroTextStyle.Title)
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
+                items(itensDesatualizados, key = { it.id }) { item ->
+                    SavroCard(modifier = Modifier.fillMaxWidth(), tone = SavroCardTone.Offline) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
+                            SavroText(item.nome, style = SavroTextStyle.Body)
+                            SavroButton(
+                                label = "Ver",
+                                onClick = { aoAbrirItem(item.id) },
+                                style = SavroButtonStyle.Secondary,
+                                loadingStateDescription = "",
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BotaoAdicionarItem(aoCriar: () -> Unit) {
+    SavroButton(label = "Adicionar item", onClick = aoCriar, loadingStateDescription = "")
+}
+
+@Composable
+private fun LinhaValor(rotulo: String, valorCentavos: Long, moeda: String, oculto: Boolean, destaque: Boolean = false) {
+    val valorFormatado = "${ConversorMonetario.centavosParaTexto(valorCentavos)} $moeda"
+    val texto = ApresentacaoValor.texto(valorFormatado, oculto)
+    val descricao = ApresentacaoValor.descricaoAcessibilidade("$rotulo: $valorFormatado", oculto)
+
+    Row(
+        modifier = Modifier.fillMaxWidth().semantics { contentDescription = descricao },
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        SavroText(rotulo, style = SavroTextStyle.Body)
+        SavroText(texto, style = if (destaque) SavroTextStyle.Title else SavroTextStyle.Body)
+    }
+}

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/PatrimonioScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/PatrimonioScreens.kt
@@ -1,5 +1,6 @@
 package io.savro.app
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,7 +8,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -19,6 +22,8 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import io.savro.common.Resultado
 import io.savro.designsystem.componentes.SavroButton
 import io.savro.designsystem.componentes.SavroButtonStyle
@@ -37,10 +42,13 @@ import io.savro.domain.patrimonio.ErroServicoPatrimonio
 import io.savro.domain.patrimonio.ErroValidacaoItem
 import io.savro.domain.patrimonio.EstadoFormularioItemPatrimonial
 import io.savro.domain.patrimonio.FiltroItensPatrimoniais
+import io.savro.domain.patrimonio.OrdenacaoItensPatrimoniais
 import io.savro.domain.patrimonio.RascunhoFormularioItem
 import io.savro.domain.patrimonio.ResumoItemPatrimonial
 import io.savro.domain.patrimonio.ServicoPatrimonio
 import io.savro.domain.patrimonio.ValidadorItemPatrimonial
+import io.savro.domain.patrimonio.calculo.ApresentacaoValor
+import io.savro.domain.patrimonio.ordenarPor
 import io.savro.model.ItemPatrimonial
 import io.savro.model.TipoItemPatrimonial
 import kotlinx.coroutines.launch
@@ -52,6 +60,7 @@ import kotlinx.coroutines.launch
  */
 private sealed class DestinoPatrimonio {
     data object Lista : DestinoPatrimonio()
+    data class Detalhe(val itemId: String) : DestinoPatrimonio()
     data class Formulario(val itemIdEmEdicao: String?) : DestinoPatrimonio()
     data class Ajuste(val itemId: String) : DestinoPatrimonio()
 
@@ -63,6 +72,7 @@ private sealed class DestinoPatrimonio {
      */
     fun paraChave(): String = when (this) {
         Lista -> ""
+        is Detalhe -> "detalhe:$itemId"
         is Formulario -> "formulario:${itemIdEmEdicao.orEmpty()}"
         is Ajuste -> "ajuste:$itemId"
     }
@@ -70,6 +80,7 @@ private sealed class DestinoPatrimonio {
     companion object {
         fun deChave(chave: String): DestinoPatrimonio = when {
             chave.isEmpty() -> Lista
+            chave.startsWith("detalhe:") -> Detalhe(chave.removePrefix("detalhe:"))
             chave.startsWith("formulario:") -> Formulario(chave.removePrefix("formulario:").takeIf { it.isNotEmpty() })
             chave.startsWith("ajuste:") -> Ajuste(chave.removePrefix("ajuste:"))
             else -> Lista
@@ -77,19 +88,76 @@ private sealed class DestinoPatrimonio {
     }
 }
 
+private enum class AbaPrincipal { HOME, PATRIMONIO }
+
+/**
+ * Orquestra a experiência principal do app (issue #120): Home, Patrimônio (lista) e Detalhe
+ * compartilham a mesma instância de [ServicoPatrimonio] (mesmos cálculos, dado único) e o mesmo
+ * estado de ocultação global de valores — alternar "ocultar" em qualquer tela vale para todas.
+ * Busca, filtro, ordenação e posição de rolagem ficam hospedados aqui (não dentro de
+ * [TelaListaPatrimonio]) para sobreviver a uma ida e volta até o Detalhe.
+ */
 @Composable
 internal fun TelaPatrimonio(servico: ServicoPatrimonio, aoAbrirConfiguracaoProtecao: () -> Unit) {
     var destino by rememberSaveable(
         stateSaver = Saver(save = { it.paraChave() }, restore = { DestinoPatrimonio.deChave(it) }),
     ) { mutableStateOf<DestinoPatrimonio>(DestinoPatrimonio.Lista) }
+    var aba by rememberSaveable { mutableStateOf(AbaPrincipal.HOME) }
+    var ocultarValores by rememberSaveable { mutableStateOf(false) }
+    var texto by rememberSaveable { mutableStateOf("") }
+    var tipoSelecionado by rememberSaveable { mutableStateOf<TipoItemPatrimonial?>(null) }
+    var mostrarArquivados by rememberSaveable { mutableStateOf(false) }
+    var ordenacao by rememberSaveable { mutableStateOf(OrdenacaoItensPatrimoniais.NOME_ASC) }
+    val estadoDaLista = rememberLazyListState()
 
     LaunchedEffect(servico) { servico.carregar() }
 
     when (val atual = destino) {
-        DestinoPatrimonio.Lista -> TelaListaPatrimonio(
+        DestinoPatrimonio.Lista -> Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(SavroThemeTokens.spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm),
+            ) {
+                SavroFilterChip(label = "Home", selected = aba == AbaPrincipal.HOME, onClick = { aba = AbaPrincipal.HOME })
+                SavroFilterChip(
+                    label = "Patrimônio",
+                    selected = aba == AbaPrincipal.PATRIMONIO,
+                    onClick = { aba = AbaPrincipal.PATRIMONIO },
+                )
+            }
+            when (aba) {
+                AbaPrincipal.HOME -> TelaHomeResumo(
+                    servico = servico,
+                    ocultarValores = ocultarValores,
+                    aoAlternarOcultarValores = { ocultarValores = !ocultarValores },
+                    aoCriar = { destino = DestinoPatrimonio.Formulario(itemIdEmEdicao = null) },
+                    aoAbrirItem = { id -> destino = DestinoPatrimonio.Detalhe(id) },
+                )
+                AbaPrincipal.PATRIMONIO -> TelaListaPatrimonio(
+                    servico = servico,
+                    ocultarValores = ocultarValores,
+                    texto = texto,
+                    aoAlterarTexto = { texto = it },
+                    tipoSelecionado = tipoSelecionado,
+                    aoAlterarTipoSelecionado = { tipoSelecionado = it },
+                    mostrarArquivados = mostrarArquivados,
+                    aoAlterarMostrarArquivados = { mostrarArquivados = it },
+                    ordenacao = ordenacao,
+                    aoAlterarOrdenacao = { ordenacao = it },
+                    estadoDaLista = estadoDaLista,
+                    aoAbrirConfiguracaoProtecao = aoAbrirConfiguracaoProtecao,
+                    aoCriar = { destino = DestinoPatrimonio.Formulario(itemIdEmEdicao = null) },
+                    aoAbrirDetalhe = { id -> destino = DestinoPatrimonio.Detalhe(id) },
+                    aoEditar = { id -> destino = DestinoPatrimonio.Formulario(itemIdEmEdicao = id) },
+                    aoAjustarValor = { id -> destino = DestinoPatrimonio.Ajuste(id) },
+                )
+            }
+        }
+        is DestinoPatrimonio.Detalhe -> TelaDetalheItem(
             servico = servico,
-            aoAbrirConfiguracaoProtecao = aoAbrirConfiguracaoProtecao,
-            aoCriar = { destino = DestinoPatrimonio.Formulario(itemIdEmEdicao = null) },
+            itemId = atual.itemId,
+            ocultarValores = ocultarValores,
+            aoVoltar = { destino = DestinoPatrimonio.Lista },
             aoEditar = { id -> destino = DestinoPatrimonio.Formulario(itemIdEmEdicao = id) },
             aoAjustarValor = { id -> destino = DestinoPatrimonio.Ajuste(id) },
         )
@@ -110,15 +178,23 @@ internal fun TelaPatrimonio(servico: ServicoPatrimonio, aoAbrirConfiguracaoProte
 @Composable
 private fun TelaListaPatrimonio(
     servico: ServicoPatrimonio,
+    ocultarValores: Boolean,
+    texto: String,
+    aoAlterarTexto: (String) -> Unit,
+    tipoSelecionado: TipoItemPatrimonial?,
+    aoAlterarTipoSelecionado: (TipoItemPatrimonial?) -> Unit,
+    mostrarArquivados: Boolean,
+    aoAlterarMostrarArquivados: (Boolean) -> Unit,
+    ordenacao: OrdenacaoItensPatrimoniais,
+    aoAlterarOrdenacao: (OrdenacaoItensPatrimoniais) -> Unit,
+    estadoDaLista: LazyListState,
     aoAbrirConfiguracaoProtecao: () -> Unit,
     aoCriar: () -> Unit,
+    aoAbrirDetalhe: (String) -> Unit,
     aoEditar: (String) -> Unit,
     aoAjustarValor: (String) -> Unit,
 ) {
     val itens by servico.itens.collectAsState()
-    var texto by remember { mutableStateOf("") }
-    var tipoSelecionado by remember { mutableStateOf<TipoItemPatrimonial?>(null) }
-    var mostrarArquivados by remember { mutableStateOf(false) }
     val escopo = rememberCoroutineScope()
 
     val filtro = FiltroItensPatrimoniais(
@@ -126,7 +202,9 @@ private fun TelaListaPatrimonio(
         tipos = tipoSelecionado?.let { setOf(it) } ?: emptySet(),
         incluirArquivados = mostrarArquivados,
     )
-    val itensFiltrados = filtro.aplicar(itens)
+    val itensFiltrados = remember(itens, texto, tipoSelecionado, mostrarArquivados, ordenacao) {
+        filtro.aplicar(itens).ordenarPor(ordenacao)
+    }
 
     Column(modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md)) {
         Row(
@@ -151,7 +229,7 @@ private fun TelaListaPatrimonio(
 
         SavroTextField(
             value = texto,
-            onValueChange = { texto = it },
+            onValueChange = aoAlterarTexto,
             label = "Buscar",
             modifier = Modifier.fillMaxWidth().padding(top = SavroThemeTokens.spacing.md),
         )
@@ -163,15 +241,48 @@ private fun TelaListaPatrimonio(
             SavroFilterChip(
                 label = "Arquivados",
                 selected = mostrarArquivados,
-                onClick = { mostrarArquivados = !mostrarArquivados },
+                onClick = { aoAlterarMostrarArquivados(!mostrarArquivados) },
             )
             TipoItemPatrimonial.entries.forEach { tipo ->
                 SavroFilterChip(
                     label = rotuloDoTipo(tipo),
                     selected = tipoSelecionado == tipo,
-                    onClick = { tipoSelecionado = if (tipoSelecionado == tipo) null else tipo },
+                    onClick = { aoAlterarTipoSelecionado(if (tipoSelecionado == tipo) null else tipo) },
                 )
             }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = SavroThemeTokens.spacing.sm),
+            horizontalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm),
+        ) {
+            SavroText("Ordenar:", style = SavroTextStyle.BodySmall)
+            SavroFilterChip(
+                label = "Nome",
+                selected = ordenacao == OrdenacaoItensPatrimoniais.NOME_ASC || ordenacao == OrdenacaoItensPatrimoniais.NOME_DESC,
+                onClick = {
+                    aoAlterarOrdenacao(
+                        if (ordenacao == OrdenacaoItensPatrimoniais.NOME_ASC) {
+                            OrdenacaoItensPatrimoniais.NOME_DESC
+                        } else {
+                            OrdenacaoItensPatrimoniais.NOME_ASC
+                        },
+                    )
+                },
+            )
+            SavroFilterChip(
+                label = "Valor",
+                selected = ordenacao == OrdenacaoItensPatrimoniais.VALOR_ASC || ordenacao == OrdenacaoItensPatrimoniais.VALOR_DESC,
+                onClick = {
+                    aoAlterarOrdenacao(
+                        if (ordenacao == OrdenacaoItensPatrimoniais.VALOR_ASC) {
+                            OrdenacaoItensPatrimoniais.VALOR_DESC
+                        } else {
+                            OrdenacaoItensPatrimoniais.VALOR_ASC
+                        },
+                    )
+                },
+            )
         }
 
         if (itensFiltrados.isEmpty()) {
@@ -183,12 +294,15 @@ private fun TelaListaPatrimonio(
             )
         } else {
             LazyColumn(
+                state = estadoDaLista,
                 modifier = Modifier.fillMaxSize().padding(top = SavroThemeTokens.spacing.md),
                 verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm),
             ) {
                 items(itensFiltrados, key = { it.id }) { item ->
                     ItemPatrimonialCard(
                         item = item,
+                        ocultarValores = ocultarValores,
+                        aoAbrirDetalhe = { aoAbrirDetalhe(item.id) },
                         aoEditar = { aoEditar(item.id) },
                         aoAjustarValor = { aoAjustarValor(item.id) },
                         aoDuplicar = { escopo.launch { servico.duplicar(item.id) } },
@@ -204,15 +318,26 @@ private fun TelaListaPatrimonio(
 @Composable
 private fun ItemPatrimonialCard(
     item: ItemPatrimonial,
+    ocultarValores: Boolean,
+    aoAbrirDetalhe: () -> Unit,
     aoEditar: () -> Unit,
     aoAjustarValor: () -> Unit,
     aoDuplicar: () -> Unit,
     aoArquivar: () -> Unit,
     aoExcluir: () -> Unit,
 ) {
-    SavroCard(modifier = Modifier.fillMaxWidth()) {
+    val valorFormatado = "${formatarValor(item)} ${item.moeda}"
+    val descricaoValor = ApresentacaoValor.descricaoAcessibilidade(valorFormatado, ocultarValores)
+
+    SavroCard(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = aoAbrirDetalhe),
+    ) {
         SavroText(item.nome, style = SavroTextStyle.Title)
-        SavroText("${rotuloDoTipo(item.tipo)} · ${formatarValor(item)} ${item.moeda}", style = SavroTextStyle.Body)
+        SavroText(
+            "${rotuloDoTipo(item.tipo)} · ${ApresentacaoValor.texto(valorFormatado, ocultarValores)}",
+            style = SavroTextStyle.Body,
+            modifier = Modifier.semantics { contentDescription = "${rotuloDoTipo(item.tipo)} · $descricaoValor" },
+        )
         item.instituicao?.let { SavroText(it, style = SavroTextStyle.BodySmall) }
         if (item.arquivado) SavroText("Arquivado", style = SavroTextStyle.Label)
 
@@ -501,10 +626,10 @@ private fun ItemPatrimonial.paraEstadoDeFormulario(): EstadoFormularioItemPatrim
         precoMedioTexto = precoMedioCentavos?.let { ConversorMonetario.centavosParaTexto(it) }.orEmpty(),
     )
 
-private fun formatarValor(item: ItemPatrimonial): String =
+internal fun formatarValor(item: ItemPatrimonial): String =
     ConversorMonetario.centavosParaTexto(item.valorCentavos)
 
-private fun rotuloDoTipo(tipo: TipoItemPatrimonial): String = when (tipo) {
+internal fun rotuloDoTipo(tipo: TipoItemPatrimonial): String = when (tipo) {
     TipoItemPatrimonial.CONTA -> "Conta"
     TipoItemPatrimonial.RENDA_VARIAVEL -> "Renda variável"
     TipoItemPatrimonial.RENDA_FIXA -> "Renda fixa"

--- a/aplicativo/shared/core/database/schemas/io.savro.database.SavroRoomDatabase/3.json
+++ b/aplicativo/shared/core/database/schemas/io.savro.database.SavroRoomDatabase/3.json
@@ -1,0 +1,171 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "e8f78baf5e16bbbf415d5d446ff8d65e",
+    "entities": [
+      {
+        "tableName": "itens_patrimoniais",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `tipo` TEXT NOT NULL, `nome` TEXT NOT NULL, `valor_centavos` INTEGER NOT NULL, `moeda` TEXT NOT NULL, `instituicao` TEXT, `observacao` TEXT, `quantidade_milesimos` INTEGER, `preco_medio_centavos` INTEGER, `origem` TEXT NOT NULL, `arquivado` INTEGER NOT NULL, `criado_em_epoca_ms` INTEGER NOT NULL, `atualizado_em_epoca_ms` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tipo",
+            "columnName": "tipo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nome",
+            "columnName": "nome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valorCentavos",
+            "columnName": "valor_centavos",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moeda",
+            "columnName": "moeda",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instituicao",
+            "columnName": "instituicao",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "observacao",
+            "columnName": "observacao",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quantidadeMilesimos",
+            "columnName": "quantidade_milesimos",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "precoMedioCentavos",
+            "columnName": "preco_medio_centavos",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "origem",
+            "columnName": "origem",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arquivado",
+            "columnName": "arquivado",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "criadoEmEpocaMs",
+            "columnName": "criado_em_epoca_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "atualizadoEmEpocaMs",
+            "columnName": "atualizado_em_epoca_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ajustes_valor_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `valor_centavos_anterior` INTEGER NOT NULL, `valor_centavos_novo` INTEGER NOT NULL, `origem` TEXT NOT NULL, `data_epoca_ms` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`item_id`) REFERENCES `itens_patrimoniais`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valorCentavosAnterior",
+            "columnName": "valor_centavos_anterior",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valorCentavosNovo",
+            "columnName": "valor_centavos_novo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "origem",
+            "columnName": "origem",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataEpocaMs",
+            "columnName": "data_epoca_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ajustes_valor_item_item_id",
+            "unique": false,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ajustes_valor_item_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "itens_patrimoniais",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e8f78baf5e16bbbf415d5d446ff8d65e')"
+    ]
+  }
+}

--- a/aplicativo/shared/core/database/schemas/io.savro.database.SavroRoomDatabase/4.json
+++ b/aplicativo/shared/core/database/schemas/io.savro.database.SavroRoomDatabase/4.json
@@ -1,0 +1,237 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "88b6a84d170f060d23a827378a2e5ef9",
+    "entities": [
+      {
+        "tableName": "itens_patrimoniais",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `tipo` TEXT NOT NULL, `nome` TEXT NOT NULL, `valor_centavos` INTEGER NOT NULL, `moeda` TEXT NOT NULL, `instituicao` TEXT, `observacao` TEXT, `quantidade_milesimos` INTEGER, `preco_medio_centavos` INTEGER, `origem` TEXT NOT NULL, `arquivado` INTEGER NOT NULL, `criado_em_epoca_ms` INTEGER NOT NULL, `atualizado_em_epoca_ms` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tipo",
+            "columnName": "tipo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nome",
+            "columnName": "nome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valorCentavos",
+            "columnName": "valor_centavos",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moeda",
+            "columnName": "moeda",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instituicao",
+            "columnName": "instituicao",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "observacao",
+            "columnName": "observacao",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "quantidadeMilesimos",
+            "columnName": "quantidade_milesimos",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "precoMedioCentavos",
+            "columnName": "preco_medio_centavos",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "origem",
+            "columnName": "origem",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arquivado",
+            "columnName": "arquivado",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "criadoEmEpocaMs",
+            "columnName": "criado_em_epoca_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "atualizadoEmEpocaMs",
+            "columnName": "atualizado_em_epoca_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ajustes_valor_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `valor_centavos_anterior` INTEGER NOT NULL, `valor_centavos_novo` INTEGER NOT NULL, `origem` TEXT NOT NULL, `data_epoca_ms` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`item_id`) REFERENCES `itens_patrimoniais`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valorCentavosAnterior",
+            "columnName": "valor_centavos_anterior",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valorCentavosNovo",
+            "columnName": "valor_centavos_novo",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "origem",
+            "columnName": "origem",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataEpocaMs",
+            "columnName": "data_epoca_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ajustes_valor_item_item_id",
+            "unique": false,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ajustes_valor_item_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "itens_patrimoniais",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "eventos_timeline_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `item_nome` TEXT NOT NULL, `tipo` TEXT NOT NULL, `data_epoca_ms` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`item_id`) REFERENCES `itens_patrimoniais`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemNome",
+            "columnName": "item_nome",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tipo",
+            "columnName": "tipo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataEpocaMs",
+            "columnName": "data_epoca_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_eventos_timeline_item_item_id",
+            "unique": false,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_eventos_timeline_item_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "itens_patrimoniais",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '88b6a84d170f060d23a827378a2e5ef9')"
+    ]
+  }
+}

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/EntidadeItemPatrimonial.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/EntidadeItemPatrimonial.kt
@@ -6,8 +6,10 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.OrigemValor
+import io.savro.model.TipoEventoTimeline
 import io.savro.model.TipoItemPatrimonial
 
 /**
@@ -103,5 +105,38 @@ internal fun EntidadeAjusteValorItem.paraModelo(): AjusteValorItem = AjusteValor
     valorCentavosAnterior = valorCentavosAnterior,
     valorCentavosNovo = valorCentavosNovo,
     origem = OrigemValor.valueOf(origem),
+    dataEpocaMs = dataEpocaMs,
+)
+
+/** Linha do tempo básica (issue #120) — append-only, nunca editada nem removida (exceto por cascata). */
+@Entity(
+    tableName = "eventos_timeline_item",
+    foreignKeys = [
+        ForeignKey(
+            entity = EntidadeItemPatrimonial::class,
+            parentColumns = ["id"],
+            childColumns = ["item_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("item_id")],
+)
+data class EntidadeEventoTimelineItem(
+    @PrimaryKey
+    val id: String,
+    @ColumnInfo(name = "item_id")
+    val itemId: String,
+    @ColumnInfo(name = "item_nome")
+    val itemNome: String,
+    val tipo: String,
+    @ColumnInfo(name = "data_epoca_ms")
+    val dataEpocaMs: Long,
+)
+
+internal fun EntidadeEventoTimelineItem.paraModelo(): EventoTimelineItem = EventoTimelineItem(
+    id = id,
+    itemId = itemId,
+    itemNome = itemNome,
+    tipo = TipoEventoTimeline.valueOf(tipo),
     dataEpocaMs = dataEpocaMs,
 )

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/ItemPatrimonialDao.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/ItemPatrimonialDao.kt
@@ -37,4 +37,13 @@ internal interface ItemPatrimonialDao {
 
     @Query("SELECT * FROM ajustes_valor_item WHERE item_id = :itemId ORDER BY data_epoca_ms ASC")
     suspend fun listarAjustes(itemId: String): List<EntidadeAjusteValorItem>
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun inserirEventoTimeline(entidade: EntidadeEventoTimelineItem)
+
+    @Query("SELECT * FROM eventos_timeline_item ORDER BY data_epoca_ms DESC")
+    suspend fun listarTimelineGlobal(): List<EntidadeEventoTimelineItem>
+
+    @Query("SELECT * FROM eventos_timeline_item WHERE item_id = :itemId ORDER BY data_epoca_ms DESC")
+    suspend fun listarTimelineDoItem(itemId: String): List<EntidadeEventoTimelineItem>
 }

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisRoom.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisRoom.kt
@@ -13,8 +13,10 @@ import io.savro.domain.patrimonio.GeradorIdItem
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
+import io.savro.model.TipoEventoTimeline
 import java.util.Arrays
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -169,6 +171,29 @@ class RepositorioItensPatrimoniaisRoom(
 
     override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
         comBancoAberto { dao -> Resultado.Sucesso(dao.listarAjustes(itemId).map { it.paraModelo() }) }
+
+    override suspend fun registrarEventoTimeline(
+        itemId: String,
+        itemNome: String,
+        tipo: TipoEventoTimeline,
+        dataEpocaMs: Long,
+    ): Resultado<EventoTimelineItem, ErroRepositorio> = comBancoAberto { dao ->
+        val entidade = EntidadeEventoTimelineItem(
+            id = GeradorIdItem.novoId(),
+            itemId = itemId,
+            itemNome = itemNome,
+            tipo = tipo.name,
+            dataEpocaMs = dataEpocaMs,
+        )
+        dao.inserirEventoTimeline(entidade)
+        Resultado.Sucesso(entidade.paraModelo())
+    }
+
+    override suspend fun listarTimeline(itemId: String?): Resultado<List<EventoTimelineItem>, ErroRepositorio> =
+        comBancoAberto { dao ->
+            val linhas = if (itemId == null) dao.listarTimelineGlobal() else dao.listarTimelineDoItem(itemId)
+            Resultado.Sucesso(linhas.map { it.paraModelo() })
+        }
 
     override suspend fun executarEmTransacao(
         bloco: suspend TransacaoItensPatrimoniais.() -> Unit,

--- a/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/SavroRoomDatabase.kt
+++ b/aplicativo/shared/core/database/src/androidMain/kotlin/io/savro/database/SavroRoomDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    entities = [EntidadeItemPatrimonial::class, EntidadeAjusteValorItem::class],
+    entities = [EntidadeItemPatrimonial::class, EntidadeAjusteValorItem::class, EntidadeEventoTimelineItem::class],
     version = EsquemaSavro.VERSAO_ATUAL,
     exportSchema = true,
 )
@@ -60,4 +60,23 @@ internal val MIGRATION_2_3: Migration = object : Migration(2, 3) {
     }
 }
 
-internal val TODAS_AS_MIGRATIONS_ROOM: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
+/** Linha do tempo básica (#120, ver [EsquemaSavro]). */
+internal val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS eventos_timeline_item (
+              id TEXT NOT NULL PRIMARY KEY,
+              item_id TEXT NOT NULL,
+              item_nome TEXT NOT NULL,
+              tipo TEXT NOT NULL,
+              data_epoca_ms INTEGER NOT NULL,
+              FOREIGN KEY(item_id) REFERENCES itens_patrimoniais(id) ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_eventos_timeline_item_item_id ON eventos_timeline_item(item_id)")
+    }
+}
+
+internal val TODAS_AS_MIGRATIONS_ROOM: Array<Migration> = arrayOf(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)

--- a/aplicativo/shared/core/database/src/androidUnitTest/kotlin/io/savro/database/RoomMigrationTest.kt
+++ b/aplicativo/shared/core/database/src/androidUnitTest/kotlin/io/savro/database/RoomMigrationTest.kt
@@ -182,6 +182,59 @@ class RoomMigrationTest {
         bancoV3.close()
     }
 
+    @Test
+    fun migracao3Para4_criaTabelaDeTimelineSemPerderItensExistentes() = runTest {
+        val arquivo = "teste-migracao-${UUID.randomUUID()}.db"
+        nomeArquivo = arquivo
+        val contexto = contexto()
+
+        // Reaproveita o schema real da v3 (SavroRoomDatabase já compilado com a entidade nova
+        // não serviria — precisamos do schema tal como estava antes da #120). Como a v3 já é
+        // idêntica ao schema de itens_patrimoniais pós #119, criamos direto via SQL bruto na v2
+        // + migration 2->3 para chegar num banco v3 realista antes de aplicar a 3->4.
+        val bancoV2 = Room.databaseBuilder(contexto, SavroRoomDatabaseV2SomenteParaTeste::class.java, arquivo)
+            .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .build()
+        bancoV2.dao().inserir(
+            EntidadeItemPatrimonialV2(
+                id = "item-1",
+                tipo = "CONTA",
+                nome = "Conta corrente",
+                valorCentavos = 1_000,
+                instituicao = null,
+                observacao = null,
+                criadoEmEpocaMs = 1,
+                atualizadoEmEpocaMs = 1,
+            ),
+        )
+        bancoV2.close()
+
+        val bancoV4 = Room.databaseBuilder(contexto, SavroRoomDatabase::class.java, arquivo)
+            .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
+            .addMigrations(*TODAS_AS_MIGRATIONS_ROOM)
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .build()
+
+        val itemMigrado = bancoV4.itemPatrimonialDao().buscarPorId("item-1")
+        assertEquals("Conta corrente", itemMigrado?.nome)
+
+        bancoV4.itemPatrimonialDao().inserirEventoTimeline(
+            EntidadeEventoTimelineItem(
+                id = "evento-1",
+                itemId = "item-1",
+                itemNome = "Conta corrente",
+                tipo = "ITEM_CRIADO",
+                dataEpocaMs = 2,
+            ),
+        )
+        val timeline = bancoV4.itemPatrimonialDao().listarTimelineDoItem("item-1")
+        assertEquals(1, timeline.size)
+        assertEquals("ITEM_CRIADO", timeline.single().tipo)
+
+        bancoV4.close()
+    }
+
     private fun contexto(): Context = ApplicationProvider.getApplicationContext()
 
     @After

--- a/aplicativo/shared/core/database/src/commonMain/kotlin/io/savro/database/EsquemaSavro.kt
+++ b/aplicativo/shared/core/database/src/commonMain/kotlin/io/savro/database/EsquemaSavro.kt
@@ -11,7 +11,7 @@ package io.savro.database
  */
 object EsquemaSavro {
     const val NOME_BANCO = "savro.db"
-    const val VERSAO_ATUAL = 3
+    const val VERSAO_ATUAL = 4
 
     val migracoes: List<DescricaoMigracao> = listOf(
         DescricaoMigracao(
@@ -26,6 +26,12 @@ object EsquemaSavro {
                 "'preco_medio_centavos', 'origem' e 'arquivado' em itens_patrimoniais; remapeia " +
                 "'INVESTIMENTO'->'RENDA_VARIAVEL' e 'IMOVEL'/'VEICULO'->'BEM' na coluna 'tipo'; cria a " +
                 "tabela 'ajustes_valor_item'",
+        ),
+        DescricaoMigracao(
+            versaoOrigem = 3,
+            versaoDestino = 4,
+            descricao = "Linha do tempo básica (#120): cria a tabela 'eventos_timeline_item' " +
+                "(id, item_id, item_nome, tipo, data_epoca_ms), FK item_id -> itens_patrimoniais ON DELETE CASCADE",
         ),
     )
 }

--- a/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/FakeRepositorioItensPatrimoniais.kt
+++ b/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/FakeRepositorioItensPatrimoniais.kt
@@ -7,8 +7,10 @@ import io.savro.domain.patrimonio.GeradorIdItem
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
+import io.savro.model.TipoEventoTimeline
 import io.savro.domain.patrimonio.ProvedorChaveMestra
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -29,6 +31,7 @@ class FakeRepositorioItensPatrimoniais(
     private val mutex = Mutex()
     private val itens = LinkedHashMap<String, ItemPatrimonial>()
     private val ajustes = mutableListOf<AjusteValorItem>()
+    private val timeline = mutableListOf<EventoTimelineItem>()
     private var aberto = false
 
     override suspend fun abrir(): Resultado<MetadadosBancoLocal, ErroRepositorio> = mutex.withLock {
@@ -70,6 +73,11 @@ class FakeRepositorioItensPatrimoniais(
         if (itens.remove(id) == null) {
             return@withLock Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(id))
         }
+        // Simula `ON DELETE CASCADE` (ajustes_valor_item/eventos_timeline_item) — mesmo
+        // comportamento que Room (FK habilitada por padrão) e SQLCipher (desde a correção do
+        // `PRAGMA foreign_keys` feita na #120).
+        ajustes.removeAll { it.itemId == id }
+        timeline.removeAll { it.itemId == id }
         Resultado.Sucesso(Unit)
     }
 
@@ -109,6 +117,31 @@ class FakeRepositorioItensPatrimoniais(
         mutex.withLock {
             exigirAberto()?.let { return@withLock Resultado.Falha(it) }
             Resultado.Sucesso(ajustes.filter { it.itemId == itemId })
+        }
+
+    override suspend fun registrarEventoTimeline(
+        itemId: String,
+        itemNome: String,
+        tipo: TipoEventoTimeline,
+        dataEpocaMs: Long,
+    ): Resultado<EventoTimelineItem, ErroRepositorio> = mutex.withLock {
+        exigirAberto()?.let { return@withLock Resultado.Falha(it) }
+        val evento = EventoTimelineItem(
+            id = GeradorIdItem.novoId(),
+            itemId = itemId,
+            itemNome = itemNome,
+            tipo = tipo,
+            dataEpocaMs = dataEpocaMs,
+        )
+        timeline += evento
+        Resultado.Sucesso(evento)
+    }
+
+    override suspend fun listarTimeline(itemId: String?): Resultado<List<EventoTimelineItem>, ErroRepositorio> =
+        mutex.withLock {
+            exigirAberto()?.let { return@withLock Resultado.Falha(it) }
+            val filtrada = if (itemId == null) timeline else timeline.filter { it.itemId == itemId }
+            Resultado.Sucesso(filtrada.sortedByDescending { it.dataEpocaMs })
         }
 
     override suspend fun executarEmTransacao(

--- a/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/RepositorioItensPatrimoniaisContratoTeste.kt
+++ b/aplicativo/shared/core/database/src/commonTest/kotlin/io/savro/database/RepositorioItensPatrimoniaisContratoTeste.kt
@@ -4,8 +4,10 @@ import io.savro.common.Resultado
 import io.savro.domain.patrimonio.ErroRepositorio
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.OrigemValor
+import io.savro.model.TipoEventoTimeline
 import io.savro.model.TipoItemPatrimonial
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -315,6 +317,46 @@ abstract class RepositorioItensPatrimoniaisContratoTeste {
         val ajustes = repositorio.listarAjustesDeValor("nao-existe")
         assertIs<Resultado.Sucesso<List<AjusteValorItem>>>(ajustes)
         assertEquals(0, ajustes.valor.size)
+
+        encerrar(repositorio)
+    }
+
+    @Test
+    fun registrarEventoTimeline_listaGlobalEPorItemMaisRecentePrimeiro() = runTest {
+        val repositorio = criarRepositorio()
+        repositorio.abrir()
+        repositorio.inserir(itemDeTeste(id = "item-1", nome = "Conta corrente"))
+        repositorio.inserir(itemDeTeste(id = "item-2", nome = "Ações XPTO"))
+
+        repositorio.registrarEventoTimeline("item-1", "Conta corrente", TipoEventoTimeline.ITEM_CRIADO, dataEpocaMs = 1)
+        repositorio.registrarEventoTimeline("item-2", "Ações XPTO", TipoEventoTimeline.ITEM_CRIADO, dataEpocaMs = 2)
+        repositorio.registrarEventoTimeline("item-1", "Conta corrente", TipoEventoTimeline.VALOR_AJUSTADO, dataEpocaMs = 3)
+
+        val global = repositorio.listarTimeline(itemId = null)
+        assertIs<Resultado.Sucesso<List<EventoTimelineItem>>>(global)
+        assertEquals(3, global.valor.size)
+        assertEquals(listOf(3L, 2L, 1L), global.valor.map { it.dataEpocaMs })
+
+        val doItem1 = repositorio.listarTimeline(itemId = "item-1")
+        assertIs<Resultado.Sucesso<List<EventoTimelineItem>>>(doItem1)
+        assertEquals(2, doItem1.valor.size)
+        assertEquals(TipoEventoTimeline.VALOR_AJUSTADO, doItem1.valor.first().tipo)
+
+        encerrar(repositorio)
+    }
+
+    @Test
+    fun excluirItem_removeSeusEventosDeTimelineEmCascata() = runTest {
+        val repositorio = criarRepositorio()
+        repositorio.abrir()
+        repositorio.inserir(itemDeTeste(id = "item-1"))
+        repositorio.registrarEventoTimeline("item-1", "Conta corrente", TipoEventoTimeline.ITEM_CRIADO, dataEpocaMs = 1)
+
+        repositorio.excluir("item-1")
+
+        val restante = repositorio.listarTimeline(itemId = "item-1")
+        assertIs<Resultado.Sucesso<List<EventoTimelineItem>>>(restante)
+        assertEquals(0, restante.valor.size)
 
         encerrar(repositorio)
     }

--- a/aplicativo/shared/core/database/src/iosMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisSQLCipher.kt
+++ b/aplicativo/shared/core/database/src/iosMain/kotlin/io/savro/database/RepositorioItensPatrimoniaisSQLCipher.kt
@@ -8,9 +8,11 @@ import io.savro.domain.patrimonio.ProvedorChaveMestra
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
 import io.savro.model.OrigemValor
+import io.savro.model.TipoEventoTimeline
 import io.savro.model.TipoItemPatrimonial
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.sync.Mutex
@@ -52,6 +54,13 @@ class RepositorioItensPatrimoniaisSQLCipher(
         return try {
             val instancia = SQLiteCifrado.abrir(caminho, chave)
             try {
+                // Achado ao implementar a #120 (timeline): `PRAGMA foreign_keys` nunca era
+                // habilitado nesta conexão — sem isso, `ON DELETE CASCADE` (já declarado desde a
+                // #119 em `ajustes_valor_item`, e agora também em `eventos_timeline_item`) nunca
+                // era aplicado de verdade no iOS; SQLite trata FK como só-documentação por padrão
+                // até este pragma ser executado em cada conexão. Precisa vir antes de qualquer
+                // outra operação na conexão.
+                instancia.executar("PRAGMA foreign_keys = ON")
                 aplicarSchemaEMigrations(instancia)
                 val total = contar(instancia)
                 banco = instancia
@@ -159,6 +168,44 @@ class RepositorioItensPatrimoniaisSQLCipher(
             Resultado.Sucesso(linhas.map(::linhaParaAjuste))
         }
 
+    override suspend fun registrarEventoTimeline(
+        itemId: String,
+        itemNome: String,
+        tipo: TipoEventoTimeline,
+        dataEpocaMs: Long,
+    ): Resultado<EventoTimelineItem, ErroRepositorio> = comBancoAberto { db ->
+        val evento = EventoTimelineItem(
+            id = GeradorIdItem.novoId(),
+            itemId = itemId,
+            itemNome = itemNome,
+            tipo = tipo,
+            dataEpocaMs = dataEpocaMs,
+        )
+        db.executar(
+            """
+            INSERT INTO eventos_timeline_item (id, item_id, item_nome, tipo, data_epoca_ms)
+            VALUES (
+                '${evento.id.escapado()}',
+                '${itemId.escapado()}',
+                '${itemNome.escapado()}',
+                '${tipo.name}',
+                $dataEpocaMs
+            )
+            """.trimIndent(),
+        )
+        Resultado.Sucesso(evento)
+    }
+
+    override suspend fun listarTimeline(itemId: String?): Resultado<List<EventoTimelineItem>, ErroRepositorio> =
+        comBancoAberto { db ->
+            val sql = if (itemId == null) {
+                "SELECT * FROM eventos_timeline_item ORDER BY data_epoca_ms DESC"
+            } else {
+                "SELECT * FROM eventos_timeline_item WHERE item_id = '${itemId.escapado()}' ORDER BY data_epoca_ms DESC"
+            }
+            Resultado.Sucesso(db.consultar(sql).map(::linhaParaEventoTimeline))
+        }
+
     override suspend fun executarEmTransacao(
         bloco: suspend TransacaoItensPatrimoniais.() -> Unit,
     ): Resultado<Unit, ErroRepositorio> {
@@ -219,6 +266,7 @@ class RepositorioItensPatrimoniaisSQLCipher(
                 """.trimIndent(),
             )
             criarTabelaDeAjustes(db)
+            criarTabelaDeTimeline(db)
             db.executar("PRAGMA user_version = ${EsquemaSavro.VERSAO_ATUAL}")
             return
         }
@@ -240,6 +288,11 @@ class RepositorioItensPatrimoniaisSQLCipher(
                 db.executar("ALTER TABLE itens_patrimoniais ADD COLUMN arquivado INTEGER NOT NULL DEFAULT 0")
                 criarTabelaDeAjustes(db)
             }
+            if (versaoAtual < 4) {
+                // Linha do tempo básica (#120). Mesma tabela que a migration 3->4 do Android
+                // (MIGRATION_3_4 em SavroRoomDatabase.kt).
+                criarTabelaDeTimeline(db)
+            }
             db.executar("PRAGMA user_version = ${EsquemaSavro.VERSAO_ATUAL}")
         }
     }
@@ -259,6 +312,22 @@ class RepositorioItensPatrimoniaisSQLCipher(
             """.trimIndent(),
         )
         db.executar("CREATE INDEX IF NOT EXISTS index_ajustes_valor_item_item_id ON ajustes_valor_item(item_id)")
+    }
+
+    private fun criarTabelaDeTimeline(db: SQLiteCifrado) {
+        db.executar(
+            """
+            CREATE TABLE IF NOT EXISTS eventos_timeline_item (
+              id TEXT NOT NULL PRIMARY KEY,
+              item_id TEXT NOT NULL,
+              item_nome TEXT NOT NULL,
+              tipo TEXT NOT NULL,
+              data_epoca_ms INTEGER NOT NULL,
+              FOREIGN KEY(item_id) REFERENCES itens_patrimoniais(id) ON DELETE CASCADE
+            )
+            """.trimIndent(),
+        )
+        db.executar("CREATE INDEX IF NOT EXISTS index_eventos_timeline_item_item_id ON eventos_timeline_item(item_id)")
     }
 
     private fun mapearExcecaoDeAbertura(excecao: Exception): Resultado<MetadadosBancoLocal, ErroRepositorio> {
@@ -315,6 +384,14 @@ private fun linhaParaAjuste(linha: Map<String, String?>): AjusteValorItem = Ajus
     valorCentavosAnterior = linha.getValue("valor_centavos_anterior")?.toLong() ?: 0,
     valorCentavosNovo = linha.getValue("valor_centavos_novo")?.toLong() ?: 0,
     origem = linha["origem"]?.let { runCatching { OrigemValor.valueOf(it) }.getOrNull() } ?: OrigemValor.MANUAL,
+    dataEpocaMs = linha.getValue("data_epoca_ms")?.toLong() ?: 0,
+)
+
+private fun linhaParaEventoTimeline(linha: Map<String, String?>): EventoTimelineItem = EventoTimelineItem(
+    id = linha.getValue("id") ?: error("linha sem id"),
+    itemId = linha.getValue("item_id") ?: error("linha sem item_id"),
+    itemNome = linha.getValue("item_nome") ?: error("linha sem item_nome"),
+    tipo = TipoEventoTimeline.valueOf(linha.getValue("tipo") ?: error("linha sem tipo")),
     dataEpocaMs = linha.getValue("data_epoca_ms")?.toLong() ?: 0,
 )
 

--- a/aplicativo/shared/core/model/src/commonMain/kotlin/io/savro/model/ItemPatrimonial.kt
+++ b/aplicativo/shared/core/model/src/commonMain/kotlin/io/savro/model/ItemPatrimonial.kt
@@ -90,3 +90,31 @@ data class MetadadosBancoLocal(
     val versaoEsquema: Int,
     val totalDeItens: Int,
 )
+
+/**
+ * Os 5 tipos de evento da "linha do tempo básica" (issue #120). Cada evento é imutável e
+ * append-only, no mesmo espírito de [AjusteValorItem] — nunca editado nem removido, exceto por
+ * cascata quando o item em si é excluído (exclusão não é um evento rastreado: "excluir" apaga o
+ * item e todo o seu histórico, não é uma alteração a exibir na linha do tempo de algo que deixou
+ * de existir).
+ */
+enum class TipoEventoTimeline {
+    ITEM_CRIADO,
+    VALOR_AJUSTADO,
+    ITEM_EDITADO,
+    ITEM_ARQUIVADO,
+    ITEM_REATIVADO,
+}
+
+/**
+ * Registro de um evento da linha do tempo básica de um item patrimonial (issue #120). `itemNome`
+ * é um instantâneo do nome no momento do evento (não uma referência viva) — preserva o histórico
+ * mesmo que o item seja renomeado depois, sem exigir join em toda leitura da timeline.
+ */
+data class EventoTimelineItem(
+    val id: String,
+    val itemId: String,
+    val itemNome: String,
+    val tipo: TipoEventoTimeline,
+    val dataEpocaMs: Long,
+)

--- a/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/FakeRepositorioItensPatrimoniais.kt
+++ b/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/FakeRepositorioItensPatrimoniais.kt
@@ -5,8 +5,10 @@ import io.savro.domain.patrimonio.ErroRepositorio
 import io.savro.domain.patrimonio.RepositorioItensPatrimoniais
 import io.savro.domain.patrimonio.TransacaoItensPatrimoniais
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
+import io.savro.model.TipoEventoTimeline
 
 /**
  * Fake mínimo de [RepositorioItensPatrimoniais] para `GerenciadorCofreTest` — só `abrir()`/
@@ -60,6 +62,16 @@ class FakeRepositorioItensPatrimoniais(
     ): Resultado<ItemPatrimonial, ErroRepositorio> = Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(itemId))
 
     override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
+        Resultado.Sucesso(emptyList())
+
+    override suspend fun registrarEventoTimeline(
+        itemId: String,
+        itemNome: String,
+        tipo: TipoEventoTimeline,
+        dataEpocaMs: Long,
+    ): Resultado<EventoTimelineItem, ErroRepositorio> = Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(itemId))
+
+    override suspend fun listarTimeline(itemId: String?): Resultado<List<EventoTimelineItem>, ErroRepositorio> =
         Resultado.Sucesso(emptyList())
 
     override suspend fun executarEmTransacao(

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/OrdenacaoItensPatrimoniais.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/OrdenacaoItensPatrimoniais.kt
@@ -1,0 +1,23 @@
+package io.savro.domain.patrimonio
+
+import io.savro.model.ItemPatrimonial
+
+/** Ordenação da lista de Patrimônio (issue #120: "ordenação por nome ou valor"). */
+enum class OrdenacaoItensPatrimoniais {
+    NOME_ASC,
+    NOME_DESC,
+    VALOR_ASC,
+    VALOR_DESC,
+}
+
+/**
+ * Aplica [ordenacao] sobre uma lista já filtrada — usada igualmente por Home (top pendências) e
+ * Patrimônio (lista completa), nunca reimplementada por tela. Ordenar por valor usa
+ * `valorCentavos` diretamente (`Long`), nunca `Double`.
+ */
+fun List<ItemPatrimonial>.ordenarPor(ordenacao: OrdenacaoItensPatrimoniais): List<ItemPatrimonial> = when (ordenacao) {
+    OrdenacaoItensPatrimoniais.NOME_ASC -> sortedBy { it.nome.lowercase() }
+    OrdenacaoItensPatrimoniais.NOME_DESC -> sortedByDescending { it.nome.lowercase() }
+    OrdenacaoItensPatrimoniais.VALOR_ASC -> sortedBy { it.valorCentavos }
+    OrdenacaoItensPatrimoniais.VALOR_DESC -> sortedByDescending { it.valorCentavos }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/RepositorioItensPatrimoniais.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/RepositorioItensPatrimoniais.kt
@@ -2,8 +2,10 @@ package io.savro.domain.patrimonio
 
 import io.savro.common.Resultado
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
+import io.savro.model.TipoEventoTimeline
 
 /**
  * Contrato de persistência do cofre patrimonial, comum a Android e iOS (ADR-002, #180).
@@ -54,6 +56,24 @@ interface RepositorioItensPatrimoniais {
 
     /** Histórico de ajustes de um item, do mais antigo para o mais recente. */
     suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio>
+
+    /**
+     * Registra um evento da linha do tempo básica (issue #120) — sempre chamado por
+     * [ServicoPatrimonio] logo após a operação de escrita correspondente já ter sido confirmada
+     * (nunca antes, para não registrar evento de algo que falhou em persistir).
+     */
+    suspend fun registrarEventoTimeline(
+        itemId: String,
+        itemNome: String,
+        tipo: TipoEventoTimeline,
+        dataEpocaMs: Long,
+    ): Resultado<EventoTimelineItem, ErroRepositorio>
+
+    /**
+     * Linha do tempo, mais recente primeiro. `itemId = null` retorna a linha do tempo global
+     * (Home); um id específico filtra para a tela de Detalhe do item.
+     */
+    suspend fun listarTimeline(itemId: String? = null): Resultado<List<EventoTimelineItem>, ErroRepositorio>
 
     /**
      * Executa [bloco] atomicamente: todas as operações de dentro se aplicam juntas, ou nenhuma se

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ServicoPatrimonio.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/ServicoPatrimonio.kt
@@ -2,8 +2,10 @@ package io.savro.domain.patrimonio
 
 import io.savro.common.Relogio
 import io.savro.common.Resultado
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.OrigemValor
+import io.savro.model.TipoEventoTimeline
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,6 +37,14 @@ class ServicoPatrimonio(
     private val mutexRecarga = Mutex()
     private val _itens = MutableStateFlow<List<ItemPatrimonial>>(emptyList())
     val itens: StateFlow<List<ItemPatrimonial>> = _itens.asStateFlow()
+
+    /**
+     * Linha do tempo básica global (issue #120), mais recente primeiro — recarregada no mesmo
+     * chokepoint que [itens] ([recarregar]), então Home/Detalhe se atualizam imediatamente junto
+     * com os totais, sem chamada explícita adicional.
+     */
+    private val _timeline = MutableStateFlow<List<EventoTimelineItem>>(emptyList())
+    val timeline: StateFlow<List<EventoTimelineItem>> = _timeline.asStateFlow()
 
     /** Deve ser chamado depois de [RepositorioItensPatrimoniais.abrir] pelo host. */
     suspend fun carregar(): Resultado<List<ItemPatrimonial>, ErroServicoPatrimonio> =
@@ -71,6 +81,7 @@ class ServicoPatrimonio(
         return when (val resultado = repositorio.inserir(item)) {
             is Resultado.Falha -> Resultado.Falha(ErroServicoPatrimonio.Persistencia(resultado.erro))
             is Resultado.Sucesso -> {
+                registrarEvento(resultado.valor.id, resultado.valor.nome, TipoEventoTimeline.ITEM_CRIADO)
                 recarregar()
                 Resultado.Sucesso(resultado.valor)
             }
@@ -103,6 +114,7 @@ class ServicoPatrimonio(
         return when (val resultado = repositorio.atualizar(itemAtualizado)) {
             is Resultado.Falha -> Resultado.Falha(mapearErroDeAtualizacao(resultado.erro))
             is Resultado.Sucesso -> {
+                registrarEvento(resultado.valor.id, resultado.valor.nome, TipoEventoTimeline.ITEM_EDITADO)
                 recarregar()
                 Resultado.Sucesso(resultado.valor)
             }
@@ -126,6 +138,7 @@ class ServicoPatrimonio(
         return when (val resultado = repositorio.inserir(copia)) {
             is Resultado.Falha -> Resultado.Falha(ErroServicoPatrimonio.Persistencia(resultado.erro))
             is Resultado.Sucesso -> {
+                registrarEvento(resultado.valor.id, resultado.valor.nome, TipoEventoTimeline.ITEM_CRIADO)
                 recarregar()
                 Resultado.Sucesso(resultado.valor)
             }
@@ -141,6 +154,8 @@ class ServicoPatrimonio(
         return when (val resultado = repositorio.atualizar(existente.copy(arquivado = arquivado))) {
             is Resultado.Falha -> Resultado.Falha(mapearErroDeAtualizacao(resultado.erro))
             is Resultado.Sucesso -> {
+                val tipoEvento = if (arquivado) TipoEventoTimeline.ITEM_ARQUIVADO else TipoEventoTimeline.ITEM_REATIVADO
+                registrarEvento(resultado.valor.id, resultado.valor.nome, tipoEvento)
                 recarregar()
                 Resultado.Sucesso(resultado.valor)
             }
@@ -190,6 +205,7 @@ class ServicoPatrimonio(
         return when (resultado) {
             is Resultado.Falha -> Resultado.Falha(mapearErroDeAtualizacao(resultado.erro))
             is Resultado.Sucesso -> {
+                registrarEvento(resultado.valor.id, resultado.valor.nome, TipoEventoTimeline.VALOR_AJUSTADO)
                 recarregar()
                 Resultado.Sucesso(resultado.valor)
             }
@@ -198,14 +214,32 @@ class ServicoPatrimonio(
 
     suspend fun listarAjustes(id: String) = repositorio.listarAjustesDeValor(id)
 
+    /** Linha do tempo de um item específico (issue #120, tela de Detalhe), mais recente primeiro. */
+    suspend fun listarTimelineDoItem(id: String) = repositorio.listarTimeline(itemId = id)
+
+    /** Instante atual — usado pela Home (issue #120) para achar itens desatualizados sem cada tela precisar do próprio [Relogio]. */
+    fun agoraEmEpocaMs(): Long = relogio.agoraEmEpocaMs()
+
     private suspend fun recarregar(): Resultado<List<ItemPatrimonial>, ErroServicoPatrimonio> = mutexRecarga.withLock {
         when (val resultado = repositorio.listarTodos()) {
             is Resultado.Falha -> Resultado.Falha(ErroServicoPatrimonio.Persistencia(resultado.erro))
             is Resultado.Sucesso -> {
                 _itens.value = resultado.valor
+                val timeline = repositorio.listarTimeline(itemId = null)
+                if (timeline is Resultado.Sucesso) _timeline.value = timeline.valor
                 Resultado.Sucesso(resultado.valor)
             }
         }
+    }
+
+    /**
+     * Melhor esforço: a linha do tempo é um registro complementar, não a fonte de verdade do
+     * item — uma falha ao gravar o evento não desfaz nem impede a operação principal (que já foi
+     * confirmada no repositório antes deste ponto). Nunca chamado antes da escrita principal ter
+     * tido sucesso.
+     */
+    private suspend fun registrarEvento(itemId: String, itemNome: String, tipo: TipoEventoTimeline) {
+        repositorio.registrarEventoTimeline(itemId, itemNome, tipo, relogio.agoraEmEpocaMs())
     }
 
     private fun mapearErroDeAtualizacao(erro: ErroRepositorio): ErroServicoPatrimonio =

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/calculo/ApresentacaoValor.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/calculo/ApresentacaoValor.kt
@@ -1,0 +1,20 @@
+package io.savro.domain.patrimonio.calculo
+
+/**
+ * Máscara de ocultação global de valores (issue #120: "valores ocultos não podem vazar em texto,
+ * gráfico, semantics/acessibilidade"). Função pura e testável: garante, no nível mais baixo
+ * possível, que nenhum dígito do valor real sobrevive ao texto/descrição exibidos quando oculto —
+ * a camada de UI (Compose) usa isto para o texto visível **e** para o `contentDescription` de
+ * leitor de tela, nunca só um dos dois.
+ */
+object ApresentacaoValor {
+    const val MASCARA: String = "••••••"
+    const val DESCRICAO_ACESSIBILIDADE_OCULTO: String = "Valor oculto"
+
+    /** Texto já formatado (ex.: "R$ 1.234,56") -> [MASCARA] quando [oculto]. */
+    fun texto(valorFormatado: String, oculto: Boolean): String = if (oculto) MASCARA else valorFormatado
+
+    /** `contentDescription` seguro para leitor de tela — nunca o valor real quando [oculto]. */
+    fun descricaoAcessibilidade(valorFormatado: String, oculto: Boolean): String =
+        if (oculto) DESCRICAO_ACESSIBILIDADE_OCULTO else valorFormatado
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/calculo/CalculoPatrimonio.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/calculo/CalculoPatrimonio.kt
@@ -1,0 +1,154 @@
+package io.savro.domain.patrimonio.calculo
+
+import io.savro.model.ItemPatrimonial
+import io.savro.model.TipoItemPatrimonial
+
+/**
+ * Totais de uma única moeda (issue #120: "patrimônio bruto", "dívidas", "patrimônio líquido").
+ *
+ * ## Convenção de sinal
+ * [dividasCentavos] é sempre >= 0 (valor absoluto) — [ItemPatrimonial.valorCentavos] de um item
+ * `DIVIDA` já é negativo no modelo (ver `ItemPatrimonial`), mas exibir "-R$ -500" duplicaria o
+ * sinal. A tela mostra [dividasCentavos] junto de um rótulo ("Dívidas") que já comunica o sentido
+ * negativo — nunca um segundo sinal de menos.
+ *
+ * [liquidoCentavos] = [brutoCentavos] - [dividasCentavos], que é exatamente a soma direta de
+ * `valorCentavos` de todos os itens não arquivados desta moeda (a convenção de sinal do modelo
+ * garante isso sem lógica condicional por tipo).
+ */
+data class TotalPorMoeda(
+    val moeda: String,
+    val brutoCentavos: Long,
+    val dividasCentavos: Long,
+    val liquidoCentavos: Long,
+)
+
+/**
+ * Resumo consolidado de patrimônio (issue #120). [totaisPorMoeda] tem no máximo 1 entrada quando
+ * [consolidavel] é `true`; quando há mais de uma moeda entre os itens não arquivados, cada moeda
+ * aparece separada e [consolidavel] é `false` — nunca somamos moedas diferentes silenciosamente
+ * como se fossem equivalentes (regra obrigatória da #120).
+ */
+data class ResumoPatrimonio(
+    val totaisPorMoeda: List<TotalPorMoeda>,
+    val consolidavel: Boolean,
+) {
+    companion object {
+        val VAZIO = ResumoPatrimonio(totaisPorMoeda = emptyList(), consolidavel = true)
+    }
+}
+
+/** Uma fatia da distribuição por classe de uma moeda. [percentualBasisPoints] é 0..10000 (1 casa == 100 = 1%). */
+data class FatiaDistribuicao(
+    val tipo: TipoItemPatrimonial,
+    val valorCentavos: Long,
+    val percentualBasisPoints: Int,
+)
+
+/** Distribuição por classe (issue #120: "distribuição básica por classe") de uma única moeda. */
+data class DistribuicaoPorClasse(
+    val moeda: String,
+    val fatias: List<FatiaDistribuicao>,
+)
+
+/**
+ * Motor de cálculo único de patrimônio — Home, Patrimônio e Detalhe usam exatamente estas funções
+ * (issue #120: "todas as telas usam os mesmos cálculos e contratos compartilhados"). Funções
+ * puras, sem I/O: recebem a lista de itens já carregada do banco local (única fonte de verdade) e
+ * nunca usam `Double`/`Float` em nenhum valor monetário.
+ *
+ * `LIMITE_DIAS_DESATUALIZADO` (issue #120: "itens que precisam de atualização") é um corte
+ * arbitrário mas explícito: item cujo `atualizadoEmEpocaMs` é mais antigo que isso entra na lista
+ * de pendências da Home. Não existe cotação automática no MVP1 (fora de escopo) — esta é a única
+ * forma de sinalizar "isso pode estar desatualizado".
+ */
+object CalculoPatrimonio {
+
+    const val LIMITE_DIAS_DESATUALIZADO: Long = 90L
+    private const val MS_POR_DIA: Long = 24L * 60L * 60L * 1000L
+    private const val BASIS_POINTS_TOTAL: Int = 10_000
+
+    /** Patrimônio bruto, dívidas e líquido — sempre sobre itens não arquivados, agrupados por moeda. */
+    fun resumo(itens: List<ItemPatrimonial>): ResumoPatrimonio {
+        val ativos = itens.filterNot { it.arquivado }
+        if (ativos.isEmpty()) return ResumoPatrimonio.VAZIO
+
+        val totais = ativos.groupBy { it.moeda }
+            .toList()
+            .sortedBy { (moeda, _) -> moeda }
+            .map { (moeda, itensDaMoeda) ->
+                val bruto = itensDaMoeda.filter { it.tipo != TipoItemPatrimonial.DIVIDA }.sumOf { it.valorCentavos }
+                val liquido = itensDaMoeda.sumOf { it.valorCentavos }
+                TotalPorMoeda(moeda = moeda, brutoCentavos = bruto, dividasCentavos = bruto - liquido, liquidoCentavos = liquido)
+            }
+
+        return ResumoPatrimonio(totaisPorMoeda = totais, consolidavel = totais.size <= 1)
+    }
+
+    /**
+     * Distribuição por classe sobre o patrimônio bruto (itens não arquivados, não-dívida) de cada
+     * moeda presente. Dívidas não entram na distribuição de classes — já aparecem separadas em
+     * [resumo]; misturar as duas quebraria a leitura de "como o patrimônio positivo está
+     * distribuído". Uma [DistribuicaoPorClasse] por moeda, na mesma ordem de [resumo].
+     *
+     * Arredondamento: percentuais em pontos-base inteiros (0..10000), calculados com divisão
+     * inteira e o resíduo distribuído pelo método do maior resto — a soma das fatias de uma moeda
+     * é sempre exatamente 10000 (nunca 9999/10001 por erro de arredondamento acumulado), sem usar
+     * `Double` em nenhum passo.
+     */
+    fun distribuicaoPorClasse(itens: List<ItemPatrimonial>): List<DistribuicaoPorClasse> {
+        val ativos = itens.filterNot { it.arquivado }.filter { it.tipo != TipoItemPatrimonial.DIVIDA }
+        return ativos.groupBy { it.moeda }
+            .toList()
+            .sortedBy { (moeda, _) -> moeda }
+            .mapNotNull { (moeda, itensDaMoeda) -> distribuicaoDeUmaMoeda(moeda, itensDaMoeda) }
+    }
+
+    private fun distribuicaoDeUmaMoeda(moeda: String, itensDaMoeda: List<ItemPatrimonial>): DistribuicaoPorClasse? {
+        val totalPorTipo = itensDaMoeda
+            .groupBy { it.tipo }
+            .toList()
+            .sortedBy { (tipo, _) -> tipo.name }
+            .associate { (tipo, itensDoTipo) -> tipo to itensDoTipo.sumOf { it.valorCentavos } }
+            .filterValues { it > 0 }
+
+        val somaTotal = totalPorTipo.values.sum()
+        if (somaTotal <= 0) return null
+
+        val fatiasComResto: List<FatiaComResto> = totalPorTipo.map { (tipo, valor) ->
+            val basisPointsExatos = valor * BASIS_POINTS_TOTAL
+            val piso = basisPointsExatos / somaTotal
+            val resto = basisPointsExatos - piso * somaTotal
+            FatiaComResto(tipo = tipo, valor = valor, pisoBasisPoints = piso, resto = resto)
+        }
+
+        val faltam = (BASIS_POINTS_TOTAL - fatiasComResto.sumOf { it.pisoBasisPoints }).toInt()
+        val basisPointsFinais = fatiasComResto.associate { it.tipo to it.pisoBasisPoints }.toMutableMap()
+        fatiasComResto.sortedByDescending { it.resto }.take(faltam).forEach { fatiaComResto ->
+            basisPointsFinais[fatiaComResto.tipo] = basisPointsFinais.getValue(fatiaComResto.tipo) + 1
+        }
+
+        val fatias = totalPorTipo.map { (tipo, valor) ->
+            FatiaDistribuicao(tipo = tipo, valorCentavos = valor, percentualBasisPoints = basisPointsFinais.getValue(tipo).toInt())
+        }.sortedByDescending { it.valorCentavos }
+
+        return DistribuicaoPorClasse(moeda = moeda, fatias = fatias)
+    }
+
+    private data class FatiaComResto(
+        val tipo: TipoItemPatrimonial,
+        val valor: Long,
+        val pisoBasisPoints: Long,
+        val resto: Long,
+    )
+
+    /** Itens não arquivados cuja última atualização passou de [LIMITE_DIAS_DESATUALIZADO] dias. */
+    fun itensQuePrecisamAtualizacao(itens: List<ItemPatrimonial>, agoraEpocaMs: Long): List<ItemPatrimonial> {
+        val limiteEpocaMs = agoraEpocaMs - (LIMITE_DIAS_DESATUALIZADO * MS_POR_DIA)
+        return itens.filterNot { it.arquivado }.filter { it.atualizadoEmEpocaMs < limiteEpocaMs }
+    }
+
+    /** Data da atualização mais recente entre os itens não arquivados, ou `null` sem nenhum item. */
+    fun dataUltimaAtualizacao(itens: List<ItemPatrimonial>): Long? =
+        itens.filterNot { it.arquivado }.maxOfOrNull { it.atualizadoEmEpocaMs }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/calculo/FormatadorData.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonMain/kotlin/io/savro/domain/patrimonio/calculo/FormatadorData.kt
@@ -1,0 +1,37 @@
+package io.savro.domain.patrimonio.calculo
+
+/**
+ * Formatação de data mínima, sem depender de `kotlinx-datetime` (evita introduzir dependência
+ * externa nova só para "dd/mm/aaaa" — decisão que precisaria de aprovação explícita fora do
+ * escopo desta issue). Usa o algoritmo civil-a-partir-de-dias de Howard Hinnant (domínio público,
+ * inteiro, correto para todo o intervalo de datas do calendário gregoriano) sobre UTC — sem
+ * `Double`, sem fuso horário local (a data exibida é só "quando o evento aconteceu", não precisa
+ * de precisão de fuso para o MVP1).
+ */
+object FormatadorData {
+
+    fun paraDataCurta(epocaMs: Long): String {
+        val diasDesdeEpoca = epocaMs.floorDiv(MS_POR_DIA)
+        val (ano, mes, dia) = civilDeDias(diasDesdeEpoca)
+        return "${dia.pad()}/${mes.pad()}/$ano"
+    }
+
+    private const val MS_POR_DIA = 24L * 60L * 60L * 1000L
+
+    private fun Int.pad(): String = if (this < 10) "0$this" else toString()
+
+    /** Howard Hinnant, "chrono-Compatible Low-Level Date Algorithms", `civil_from_days`. */
+    private fun civilDeDias(diasEpoca: Long): Triple<Int, Int, Int> {
+        val z = diasEpoca + 719_468L
+        val era = z.floorDiv(146_097L)
+        val doe = z - era * 146_097L
+        val yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365
+        val y = yoe + era * 400
+        val doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+        val mp = (5 * doy + 2) / 153
+        val d = (doy - (153 * mp + 2) / 5 + 1).toInt()
+        val m = (if (mp < 10) mp + 3 else mp - 9).toInt()
+        val anoFinal = (if (m <= 2) y + 1 else y).toInt()
+        return Triple(anoFinal, m, d)
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/FakeRepositorioItensPatrimoniaisSimples.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/FakeRepositorioItensPatrimoniaisSimples.kt
@@ -3,8 +3,10 @@ package io.savro.domain.patrimonio
 import io.savro.common.Relogio
 import io.savro.common.Resultado
 import io.savro.model.AjusteValorItem
+import io.savro.model.EventoTimelineItem
 import io.savro.model.ItemPatrimonial
 import io.savro.model.MetadadosBancoLocal
+import io.savro.model.TipoEventoTimeline
 
 /**
  * Fake mínimo para testar [ServicoPatrimonio] sem depender de `:shared:core:database` (que
@@ -21,6 +23,7 @@ class FakeRepositorioItensPatrimoniaisSimples(
 
     private val itens = LinkedHashMap<String, ItemPatrimonial>()
     private val ajustes = mutableListOf<AjusteValorItem>()
+    private val timeline = mutableListOf<EventoTimelineItem>()
 
     override suspend fun abrir(): Resultado<MetadadosBancoLocal, ErroRepositorio> =
         Resultado.Sucesso(MetadadosBancoLocal(1, itens.size))
@@ -43,6 +46,9 @@ class FakeRepositorioItensPatrimoniaisSimples(
     override suspend fun excluir(id: String): Resultado<Unit, ErroRepositorio> {
         falhaSimulada?.let { return Resultado.Falha(it) }
         if (itens.remove(id) == null) return Resultado.Falha(ErroRepositorio.ItemNaoEncontrado(id))
+        // Simula `ON DELETE CASCADE`, igual às engines reais (Room/SQLCipher).
+        ajustes.removeAll { it.itemId == id }
+        timeline.removeAll { it.itemId == id }
         return Resultado.Sucesso(Unit)
     }
 
@@ -74,6 +80,29 @@ class FakeRepositorioItensPatrimoniaisSimples(
 
     override suspend fun listarAjustesDeValor(itemId: String): Resultado<List<AjusteValorItem>, ErroRepositorio> =
         Resultado.Sucesso(ajustes.filter { it.itemId == itemId })
+
+    override suspend fun registrarEventoTimeline(
+        itemId: String,
+        itemNome: String,
+        tipo: TipoEventoTimeline,
+        dataEpocaMs: Long,
+    ): Resultado<EventoTimelineItem, ErroRepositorio> {
+        falhaSimulada?.let { return Resultado.Falha(it) }
+        val evento = EventoTimelineItem(
+            id = GeradorIdItem.novoId(),
+            itemId = itemId,
+            itemNome = itemNome,
+            tipo = tipo,
+            dataEpocaMs = dataEpocaMs,
+        )
+        timeline += evento
+        return Resultado.Sucesso(evento)
+    }
+
+    override suspend fun listarTimeline(itemId: String?): Resultado<List<EventoTimelineItem>, ErroRepositorio> {
+        val filtrada = if (itemId == null) timeline else timeline.filter { it.itemId == itemId }
+        return Resultado.Sucesso(filtrada.sortedByDescending { it.dataEpocaMs })
+    }
 
     override suspend fun executarEmTransacao(
         bloco: suspend TransacaoItensPatrimoniais.() -> Unit,

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/OrdenacaoItensPatrimoniaisTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/OrdenacaoItensPatrimoniaisTest.kt
@@ -1,0 +1,52 @@
+package io.savro.domain.patrimonio
+
+import io.savro.model.ItemPatrimonial
+import io.savro.model.OrigemValor
+import io.savro.model.TipoItemPatrimonial
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OrdenacaoItensPatrimoniaisTest {
+
+    private fun item(nome: String, valorCentavos: Long): ItemPatrimonial = ItemPatrimonial(
+        id = nome,
+        tipo = TipoItemPatrimonial.CONTA,
+        nome = nome,
+        valorCentavos = valorCentavos,
+        moeda = "BRL",
+        instituicao = null,
+        observacao = null,
+        quantidadeMilesimos = null,
+        precoMedioCentavos = null,
+        origem = OrigemValor.MANUAL,
+        arquivado = false,
+        criadoEmEpocaMs = 0,
+        atualizadoEmEpocaMs = 0,
+    )
+
+    private val itens = listOf(item("Zebra", 500), item("Ações", 100_000), item("banco", 10))
+
+    @Test
+    fun ordenaPorNomeAscendenteIgnorandoCaixa() {
+        val resultado = itens.ordenarPor(OrdenacaoItensPatrimoniais.NOME_ASC).map { it.nome }
+        assertEquals(listOf("Ações", "banco", "Zebra"), resultado)
+    }
+
+    @Test
+    fun ordenaPorNomeDescendente() {
+        val resultado = itens.ordenarPor(OrdenacaoItensPatrimoniais.NOME_DESC).map { it.nome }
+        assertEquals(listOf("Zebra", "banco", "Ações"), resultado)
+    }
+
+    @Test
+    fun ordenaPorValorAscendente() {
+        val resultado = itens.ordenarPor(OrdenacaoItensPatrimoniais.VALOR_ASC).map { it.valorCentavos }
+        assertEquals(listOf(10L, 500L, 100_000L), resultado)
+    }
+
+    @Test
+    fun ordenaPorValorDescendente() {
+        val resultado = itens.ordenarPor(OrdenacaoItensPatrimoniais.VALOR_DESC).map { it.valorCentavos }
+        assertEquals(listOf(100_000L, 500L, 10L), resultado)
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ServicoPatrimonioTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ServicoPatrimonioTest.kt
@@ -1,6 +1,7 @@
 package io.savro.domain.patrimonio
 
 import io.savro.common.Resultado
+import io.savro.model.TipoEventoTimeline
 import io.savro.model.TipoItemPatrimonial
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -165,5 +166,95 @@ class ServicoPatrimonioTest {
         )
         assertEquals(1, resultado.size)
         assertEquals("Ações Nubank", resultado.single().nome)
+    }
+
+    // --- Linha do tempo básica (issue #120) — os 5 tipos de evento e reatividade imediata. ---
+
+    @Test
+    fun criar_registraEventoItemCriadoNaTimelineImediatamente() = runTest {
+        val (servico, _, _) = novoServico()
+        val criado = (servico.criar(estadoConta(nome = "Conta Itaú")) as Resultado.Sucesso).valor
+
+        assertEquals(1, servico.timeline.value.size)
+        val evento = servico.timeline.value.single()
+        assertEquals(TipoEventoTimeline.ITEM_CRIADO, evento.tipo)
+        assertEquals(criado.id, evento.itemId)
+        assertEquals("Conta Itaú", evento.itemNome)
+    }
+
+    @Test
+    fun editar_registraEventoItemEditadoNaTimeline() = runTest {
+        val relogio = RelogioDeTesteSimples()
+        val (servico, _, rel) = novoServico(relogio)
+        val criado = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        rel.avancar(1_000)
+        servico.editar(estadoConta(nome = "Conta renomeada").copy(itemIdEmEdicao = criado.id))
+
+        assertEquals(TipoEventoTimeline.ITEM_EDITADO, servico.timeline.value.first().tipo)
+    }
+
+    @Test
+    fun ajustarValor_registraEventoValorAjustadoNaTimeline() = runTest {
+        val relogio = RelogioDeTesteSimples()
+        val (servico, _, rel) = novoServico(relogio)
+        val criado = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        rel.avancar(1_000)
+        servico.ajustarValor(criado.id, "2.000,00")
+
+        assertEquals(TipoEventoTimeline.VALOR_AJUSTADO, servico.timeline.value.first().tipo)
+    }
+
+    @Test
+    fun arquivarEReativar_registramEventosDistintosNaTimeline() = runTest {
+        val relogio = RelogioDeTesteSimples()
+        val (servico, _, rel) = novoServico(relogio)
+        val criado = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        rel.avancar(1_000)
+        servico.arquivar(criado.id, arquivado = true)
+        assertEquals(TipoEventoTimeline.ITEM_ARQUIVADO, servico.timeline.value.first().tipo)
+
+        rel.avancar(1_000)
+        servico.arquivar(criado.id, arquivado = false)
+        assertEquals(TipoEventoTimeline.ITEM_REATIVADO, servico.timeline.value.first().tipo)
+
+        // criado + arquivado + reativado — todos os eventos ficam registrados, nenhum é perdido.
+        assertEquals(3, servico.timeline.value.size)
+    }
+
+    @Test
+    fun arquivar_semMudarEstado_naoRegistraEventoDuplicado() = runTest {
+        val (servico, _, _) = novoServico()
+        val criado = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+
+        servico.arquivar(criado.id, arquivado = false) // já não está arquivado — noop
+        assertEquals(1, servico.timeline.value.size) // só o ITEM_CRIADO
+    }
+
+    @Test
+    fun duplicar_registraEventoItemCriadoParaACopia() = runTest {
+        val (servico, _, _) = novoServico()
+        val original = (servico.criar(estadoConta()) as Resultado.Sucesso).valor
+        servico.duplicar(original.id)
+
+        val eventosDeCriacao = servico.timeline.value.filter { it.tipo == TipoEventoTimeline.ITEM_CRIADO }
+        assertEquals(2, eventosDeCriacao.size)
+    }
+
+    @Test
+    fun listarTimelineDoItem_filtraApenasEventosDoItemInformado() = runTest {
+        val (servico, _, _) = novoServico()
+        val item1 = (servico.criar(estadoConta(nome = "Item 1")) as Resultado.Sucesso).valor
+        val item2 = (servico.criar(estadoConta(nome = "Item 2")) as Resultado.Sucesso).valor
+        servico.ajustarValor(item1.id, "50,00")
+
+        val timelineItem1 = (servico.listarTimelineDoItem(item1.id) as Resultado.Sucesso).valor
+        assertEquals(2, timelineItem1.size) // CRIADO + VALOR_AJUSTADO
+        assertTrue(timelineItem1.all { it.itemId == item1.id })
+
+        val timelineItem2 = (servico.listarTimelineDoItem(item2.id) as Resultado.Sucesso).valor
+        assertEquals(1, timelineItem2.size)
     }
 }

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/ApresentacaoValorTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/ApresentacaoValorTest.kt
@@ -1,0 +1,32 @@
+package io.savro.domain.patrimonio.calculo
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class ApresentacaoValorTest {
+
+    @Test
+    fun texto_visivel_retornaOValorFormatadoSemAlteracao() {
+        assertEquals("R$ 1.234,56", ApresentacaoValor.texto("R$ 1.234,56", oculto = false))
+    }
+
+    @Test
+    fun texto_oculto_nuncaContemNenhumDigitoDoValorReal() {
+        val mascarado = ApresentacaoValor.texto("R$ 1.234,56", oculto = true)
+        assertFalse(mascarado.any { it.isDigit() })
+        assertEquals(ApresentacaoValor.MASCARA, mascarado)
+    }
+
+    @Test
+    fun descricaoAcessibilidade_oculto_nuncaExpoeOValorAoLeitorDeTela() {
+        val descricao = ApresentacaoValor.descricaoAcessibilidade("R$ 999.999,99", oculto = true)
+        assertFalse(descricao.any { it.isDigit() })
+        assertEquals(ApresentacaoValor.DESCRICAO_ACESSIBILIDADE_OCULTO, descricao)
+    }
+
+    @Test
+    fun descricaoAcessibilidade_visivel_retornaOValorReal() {
+        assertEquals("R$ 10,00", ApresentacaoValor.descricaoAcessibilidade("R$ 10,00", oculto = false))
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/CalculoPatrimonioTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/CalculoPatrimonioTest.kt
@@ -1,0 +1,160 @@
+package io.savro.domain.patrimonio.calculo
+
+import io.savro.model.ItemPatrimonial
+import io.savro.model.OrigemValor
+import io.savro.model.TipoItemPatrimonial
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CalculoPatrimonioTest {
+
+    private fun item(
+        id: String,
+        tipo: TipoItemPatrimonial,
+        valorCentavos: Long,
+        moeda: String = "BRL",
+        arquivado: Boolean = false,
+        atualizadoEmEpocaMs: Long = 0,
+    ): ItemPatrimonial = ItemPatrimonial(
+        id = id,
+        tipo = tipo,
+        nome = "Item $id",
+        valorCentavos = valorCentavos,
+        moeda = moeda,
+        instituicao = null,
+        observacao = null,
+        quantidadeMilesimos = null,
+        precoMedioCentavos = null,
+        origem = OrigemValor.MANUAL,
+        arquivado = arquivado,
+        criadoEmEpocaMs = 0,
+        atualizadoEmEpocaMs = atualizadoEmEpocaMs,
+    )
+
+    @Test
+    fun resumo_semItens_retornaZeradoEConsolidavel() {
+        val resumo = CalculoPatrimonio.resumo(emptyList())
+        assertEquals(ResumoPatrimonio.VAZIO, resumo)
+        assertTrue(resumo.consolidavel)
+        assertTrue(resumo.totaisPorMoeda.isEmpty())
+    }
+
+    @Test
+    fun resumo_calculaBrutoDividasELiquidoDeUmaUnicaMoeda() {
+        val itens = listOf(
+            item("conta", TipoItemPatrimonial.CONTA, 100_000),
+            item("acoes", TipoItemPatrimonial.RENDA_VARIAVEL, 50_000),
+            item("divida", TipoItemPatrimonial.DIVIDA, -30_000),
+        )
+        val resumo = CalculoPatrimonio.resumo(itens)
+
+        assertTrue(resumo.consolidavel)
+        val total = resumo.totaisPorMoeda.single()
+        assertEquals("BRL", total.moeda)
+        assertEquals(150_000L, total.brutoCentavos)
+        // dívida é sempre exibida como valor absoluto — nunca "-R$ -300,00" (duplicação de sinal).
+        assertEquals(30_000L, total.dividasCentavos)
+        assertEquals(120_000L, total.liquidoCentavos)
+    }
+
+    @Test
+    fun resumo_itemArquivado_naoEntraEmNenhumTotal() {
+        val itens = listOf(
+            item("ativo", TipoItemPatrimonial.CONTA, 100_000),
+            item("arquivado", TipoItemPatrimonial.CONTA, 999_999, arquivado = true),
+        )
+        val total = CalculoPatrimonio.resumo(itens).totaisPorMoeda.single()
+        assertEquals(100_000L, total.brutoCentavos)
+        assertEquals(100_000L, total.liquidoCentavos)
+    }
+
+    @Test
+    fun resumo_somenteDividas_liquidoNegativoEBrutoZero() {
+        val itens = listOf(item("divida", TipoItemPatrimonial.DIVIDA, -50_000))
+        val total = CalculoPatrimonio.resumo(itens).totaisPorMoeda.single()
+        assertEquals(0L, total.brutoCentavos)
+        assertEquals(50_000L, total.dividasCentavos)
+        assertEquals(-50_000L, total.liquidoCentavos)
+    }
+
+    @Test
+    fun resumo_multiplasMoedas_naoConsolidaSilenciosamente() {
+        val itens = listOf(
+            item("conta-brl", TipoItemPatrimonial.CONTA, 100_000, moeda = "BRL"),
+            item("conta-usd", TipoItemPatrimonial.CONTA, 20_000, moeda = "USD"),
+        )
+        val resumo = CalculoPatrimonio.resumo(itens)
+
+        assertEquals(false, resumo.consolidavel)
+        assertEquals(2, resumo.totaisPorMoeda.size)
+        assertEquals(100_000L, resumo.totaisPorMoeda.single { it.moeda == "BRL" }.brutoCentavos)
+        assertEquals(20_000L, resumo.totaisPorMoeda.single { it.moeda == "USD" }.brutoCentavos)
+    }
+
+    @Test
+    fun distribuicaoPorClasse_somaExatamente10000BasisPointsApesarDeDivisaoNaoExata() {
+        // 3 itens de 1000 centavos cada => 1/3 exato não existe em base 10 — testa o método do
+        // maior resto sem nunca usar Double.
+        val itens = listOf(
+            item("a", TipoItemPatrimonial.CONTA, 1_000),
+            item("b", TipoItemPatrimonial.RENDA_FIXA, 1_000),
+            item("c", TipoItemPatrimonial.CRIPTO, 1_000),
+        )
+        val distribuicao = CalculoPatrimonio.distribuicaoPorClasse(itens).single()
+        assertEquals(10_000, distribuicao.fatias.sumOf { it.percentualBasisPoints })
+        assertEquals(3, distribuicao.fatias.size)
+    }
+
+    @Test
+    fun distribuicaoPorClasse_ignoraDividasEItensArquivados() {
+        val itens = listOf(
+            item("conta", TipoItemPatrimonial.CONTA, 100_000),
+            item("divida", TipoItemPatrimonial.DIVIDA, -50_000),
+            item("arquivado", TipoItemPatrimonial.CRIPTO, 999_999, arquivado = true),
+        )
+        val distribuicao = CalculoPatrimonio.distribuicaoPorClasse(itens).single()
+        assertEquals(1, distribuicao.fatias.size)
+        assertEquals(TipoItemPatrimonial.CONTA, distribuicao.fatias.single().tipo)
+        assertEquals(10_000, distribuicao.fatias.single().percentualBasisPoints)
+    }
+
+    @Test
+    fun distribuicaoPorClasse_semItensPositivos_retornaListaVazia() {
+        assertTrue(CalculoPatrimonio.distribuicaoPorClasse(emptyList()).isEmpty())
+        assertTrue(
+            CalculoPatrimonio.distribuicaoPorClasse(listOf(item("divida", TipoItemPatrimonial.DIVIDA, -1_000))).isEmpty(),
+        )
+    }
+
+    @Test
+    fun itensQuePrecisamAtualizacao_filtraPeloLimiteDeDiasEIgnoraArquivados() {
+        val umDiaEmMs = 24L * 60 * 60 * 1000
+        val agora = 1_000L * umDiaEmMs
+        val limiteEmMs = CalculoPatrimonio.LIMITE_DIAS_DESATUALIZADO * umDiaEmMs
+
+        val itens = listOf(
+            item("recente", TipoItemPatrimonial.CONTA, 1, atualizadoEmEpocaMs = agora),
+            item("antigo", TipoItemPatrimonial.CONTA, 1, atualizadoEmEpocaMs = agora - limiteEmMs - umDiaEmMs),
+            item("antigoArquivado", TipoItemPatrimonial.CONTA, 1, atualizadoEmEpocaMs = 0, arquivado = true),
+        )
+
+        val pendentes = CalculoPatrimonio.itensQuePrecisamAtualizacao(itens, agoraEpocaMs = agora)
+        assertEquals(listOf("antigo"), pendentes.map { it.id })
+    }
+
+    @Test
+    fun dataUltimaAtualizacao_semItens_retornaNull() {
+        assertEquals(null, CalculoPatrimonio.dataUltimaAtualizacao(emptyList()))
+    }
+
+    @Test
+    fun dataUltimaAtualizacao_ignoraArquivadosERetornaAMaisRecente() {
+        val itens = listOf(
+            item("antigo", TipoItemPatrimonial.CONTA, 1, atualizadoEmEpocaMs = 100),
+            item("recente", TipoItemPatrimonial.CONTA, 1, atualizadoEmEpocaMs = 500),
+            item("arquivadoMaisRecente", TipoItemPatrimonial.CONTA, 1, atualizadoEmEpocaMs = 999, arquivado = true),
+        )
+        assertEquals(500L, CalculoPatrimonio.dataUltimaAtualizacao(itens))
+    }
+}

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/FormatadorDataTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/FormatadorDataTest.kt
@@ -1,0 +1,19 @@
+package io.savro.domain.patrimonio.calculo
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FormatadorDataTest {
+
+    @Test
+    fun paraDataCurta_epocaZero_ehPrimeiroDeJaneiroDe1970() {
+        assertEquals("01/01/1970", FormatadorData.paraDataCurta(0))
+    }
+
+    @Test
+    fun paraDataCurta_datasConhecidas() {
+        assertEquals("14/11/2023", FormatadorData.paraDataCurta(1_700_000_000_000))
+        assertEquals("09/09/2001", FormatadorData.paraDataCurta(1_000_000_000_000))
+        assertEquals("01/01/2021", FormatadorData.paraDataCurta(1_609_459_200_000))
+    }
+}


### PR DESCRIPTION
## Objetivo

Entrega a experiência principal do Savro (issue #120) sobre o cofre/CRUD já
implementados nas #118/#119: Home, Patrimônio (lista), Detalhe do item e linha
do tempo básica — banco local como única fonte de verdade, 100% offline.

## O que foi implementado

**Módulo de cálculo compartilhado** (`io.savro.domain.patrimonio.calculo`,
`shared/domain/patrimonio`) — usado igualmente por Home, Patrimônio e Detalhe,
nenhuma tela recalcula por conta própria:
- `CalculoPatrimonio`: patrimônio bruto, dívidas (sempre valor absoluto — nunca
  "-R$ -500"), patrimônio líquido, tudo agrupado por moeda; distribuição por
  classe em pontos-base inteiros (método do maior resto, soma sempre 10000, sem
  `Double`); itens que precisam de atualização (>90 dias sem ajuste); data da
  última atualização.
- `ApresentacaoValor`: máscara de ocultação global — texto e `contentDescription`
  de acessibilidade nunca contêm dígito do valor real quando oculto.
- `FormatadorData`: `dd/mm/aaaa` sem introduzir dependência nova (`kotlinx-datetime`
  não foi adicionada — algoritmo civil-a-partir-de-dias, inteiro, sem fuso).

**Múltiplas moedas**: `ResumoPatrimonio.consolidavel` é `false` quando há mais de
uma moeda entre os itens não arquivados — cada moeda aparece com seus próprios
totais, nunca somadas silenciosamente.

**Linha do tempo básica** (`EventoTimelineItem`/`TipoEventoTimeline` em
`core:model`): tabela nova `eventos_timeline_item` (migration de schema 3→4,
espelhada em Room/Android e SQLCipher/iOS), `ON DELETE CASCADE` por item.
`ServicoPatrimonio` registra evento após cada operação confirmada (criar →
`ITEM_CRIADO`, editar → `ITEM_EDITADO`, ajustar valor → `VALOR_AJUSTADO`,
arquivar/reativar → `ITEM_ARQUIVADO`/`ITEM_REATIVADO`, duplicar → `ITEM_CRIADO`
para a cópia) e expõe `timeline: StateFlow<...>` — mesma reatividade imediata que
`itens` já usava.

**UI (Compose Multiplatform, `shared/app`)**:
- `TelaHomeResumo` (nova): totais, distribuição, itens desatualizados, CTA
  "Adicionar item".
- `TelaDetalheItem` (nova): nome/classe/instituição/moeda/valor atual/valor
  investido (quando quantidade+preço médio existirem)/observações/data e origem
  da atualização, ações (editar/ajustar valor/duplicar/arquivar/excluir) e a
  timeline do item.
- `TelaPatrimonio`/`TelaListaPatrimonio` (estendidas, não redesenhadas):
  ordenação por nome/valor, ocultação global (compartilhada com Home e Detalhe
  via estado hospedado no orquestrador), busca/filtro/ordenação/rolagem
  preservados com `rememberSaveable`/`rememberLazyListState`, acesso ao Detalhe
  por tap no item.
- Todas reaproveitam os componentes existentes do design system
  (`SavroCard`, `SavroButton`, `SavroFilterChip`, `SavroText`, `SavroStatePanel`,
  `SavroDivider`) — nenhum componente paralelo criado.

## Achado e correção de fronteira KMP/iOS

O wrapper SQLCipher do iOS (`SQLiteCifrado`) nunca habilitava `PRAGMA
foreign_keys` — `ON DELETE CASCADE` (já usado por `ajustes_valor_item` desde a
#119, e agora por `eventos_timeline_item`) nunca era de fato aplicado nessa
plataforma. Corrigido: `PRAGMA foreign_keys = ON` logo após abrir a conexão.

## Testes

`commonTest` novo/estendido: `CalculoPatrimonioTest` (11), `OrdenacaoItensPatrimoniaisTest` (4),
`ApresentacaoValorTest` (4), `FormatadorDataTest` (2), `ServicoPatrimonioTest`
(+8 casos de timeline/reatividade), mais 2 casos de contrato de repositório
(timeline global/por item, cascade delete) rodados contra Fake + Room + SQLCipher.

Localmente (Windows): `domain:patrimonio`, `core:security`, `core:designsystem`,
`core:testing` e `androidApp` — testes, lint e `assembleDevDebug` verdes;
`verifyArchitecture`/`verifyDesignSystemTokens` ok. `core:database:testDebugUnitTest`
teve 3 falhas *só neste ambiente local* (Robolectric/Windows) — 2 delas já falhavam
identicamente no `master` sem nenhuma mudança desta branch (confirmado via
`git stash` antes de abrir este PR). Não é regressão desta branch nem do
ambiente de CI real: confirmado abaixo.

**CI real (`ubuntu-latest` + `macos-14`) — 100% verde, todos os 6 jobs, incluindo
o job `ios-xcode-macos` (link do framework + build do Xcode, 8m25s):** os 3 testes
que falhavam no Robolectric/Windows local passaram normalmente no job
"Testes de commonTest e módulos compartilhados" (ubuntu-latest) — confirma que
era mesmo um artefato do ambiente local, não do código.

## Divergência de escopo (pedido pelo coordenador durante a execução)

Uma mensagem recebida a meio da implementação pediu também revisão visual
completa de **todas** as telas de #118/#119 contra os protótipos "online atuais"
(`claude.ai/design`, tool `DesignSync`). Não tenho acesso a essa ferramenta nem a
navegador neste ambiente — só aos espelhos locais em
`documentacao/produto/SAVRO_PROTOTIPOS.md` e `documentacao/marca/SAVRO_DESIGN_SYSTEM.md`,
que já declaram não substituir o sync ao vivo. Usei esses espelhos como melhor
fonte disponível (tokens/componentes do design system já implementados batem com
o que está documentado ali) e mantive a linguagem visual e os componentes já
estabelecidos pelas #118/#119 nas telas novas, sem introduzir nada paralelo — mas
não fiz (nem poderia fazer com confiabilidade) uma auditoria pixel-a-pixel contra
o protótipo vivo. Registrando essa limitação explicitamente em vez de alegar
paridade que não pude verificar.

## Pendências reais

- Ordenação/preservação de estado testada só via inspeção de código + testes de
  unidade da lógica pura (`ordenarPor`, `FiltroItensPatrimoniais`) — sem teste de
  UI instrumentado para "rolagem preservada" de verdade em device/simulador real.
- Auditoria visual completa de #118/#119 contra o protótipo vivo não foi possível
  nesta sessão (ver seção acima) — recomendo tarefa dedicada com acesso a
  `DesignSync`/navegador.
- CI real já confirmada 100% verde (ver seção Testes) — sem pendência de validação
  de build/compile restante nesta entrega.

Closes #120
