### PR TITLE
chore: ignora cache Gradle rodado fora de aplicativo/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,11 @@ aplicativo/**/*.apk
 aplicativo/**/*.aab
 aplicativo/**/*.apks
 
+# Gradle rodado por engano fora de aplicativo/ (raiz do repo não é projeto Gradle)
+/.gradle/
+/.kotlin/
+/android/
+
 # Aplicativo KMP — host Xcode (iOS)
 aplicativo/iosApp/**/xcuserdata/
 aplicativo/iosApp/**/*.xcworkspace/xcuserdata/


### PR DESCRIPTION
## Contexto

Foi encontrada uma pasta `android/` solta na raiz do repo (`.gradle/`, `.kotlin/`, `app/`, `core/`,
`domain/`, `hs_err_pid*.log`) — cache de uma execução do Gradle feita por engano na raiz em vez de
dentro de `aplicativo/` (projeto Gradle real, ADR-002). Confirmado que:
- nada estava rastreado (`git ls-files android/` = 0 arquivos);
- nenhum workflow (`.github/workflows/aplicativo-ci.yml`), script ou config de build referencia
  `android/` na raiz — tudo aponta para `aplicativo/`;
- as únicas ocorrências da string "android/" fora dessa pasta eram substrings de
  `@capacitor/android` em `package-lock.json`, sem relação.

Pasta local já removida (não rastreada, remoção não gera diff de arquivo versionado).

## Mudança

Adiciona ao `.gitignore` os padrões `/.gradle/`, `/.kotlin/` e `/android/` (âncorados na raiz, não
afetam os equivalentes já ignorados dentro de `aplicativo/`), para evitar que esse cache volte a
ser commitado por engano caso o Gradle seja rodado novamente na raiz.

## Links e referências

* Encontrado durante o merge da #219 (Closes #120).