### PR TITLE
feat(#179): consolidar regras patrimoniais em commonMain

### DIFF
--- a/.github/workflows/aplicativo-ci.yml
+++ b/.github/workflows/aplicativo-ci.yml
@@ -184,13 +184,26 @@ jobs:
       # plataforma do Kotlin/Native, que existem também no host Linux. É a rede de segurança barata
       # para erro de cinterop na criptografia e no seletor de arquivos do iOS, antes do runner
       # macOS.
+      #
+      # :shared:core:model e :shared:domain:patrimonio (#179) entram aqui pelo mesmo motivo: são
+      # módulos "puros" (sem cinterop, sem CocoaPods, ver `pureModulePaths` em `verifyArchitecture`)
+      # que hospedam as regras patrimoniais canônicas — compilam em Linux tão bem quanto em macOS.
+      # Antes da #179 nenhum dos dois aparecia em nenhum job de CI para os alvos iOS: os targets
+      # `iosArm64()`/`iosSimulatorArm64()` já estavam declarados nos respectivos `build.gradle.kts`
+      # desde a #119/#120, mas nunca tinham sido de fato compilados nem testados em iOS — só no
+      # `androidUnitTest` da JVM (job "testes-comuns"). "Compila igual nos dois lados" era suposição,
+      # não evidência.
       - name: Compilar alvos iOS (klib, sem link)
         run: |
           ./gradlew --no-daemon --stacktrace \
             :shared:core:security:compileKotlinIosArm64 \
             :shared:core:security:compileKotlinIosSimulatorArm64 \
             :shared:core:backup:compileKotlinIosArm64 \
-            :shared:core:backup:compileKotlinIosSimulatorArm64
+            :shared:core:backup:compileKotlinIosSimulatorArm64 \
+            :shared:core:model:compileKotlinIosArm64 \
+            :shared:core:model:compileKotlinIosSimulatorArm64 \
+            :shared:domain:patrimonio:compileKotlinIosArm64 \
+            :shared:domain:patrimonio:compileKotlinIosSimulatorArm64
 
   ios-xcode-macos:
     name: Link do framework e build do Xcode (runner macOS)
@@ -251,6 +264,18 @@ jobs:
       # divergiu entre as plataformas — não é teste de fachada.
       - name: Testar backup/restauração/CSV no simulador iOS (vetores compartilhados)
         run: ./gradlew --no-daemon --stacktrace :shared:core:backup:iosSimulatorArm64Test
+
+      # Evidência de paridade Android <-> iOS das regras patrimoniais canônicas (#179, critério de
+      # aceite "Android e iOS consomem a mesma implementação"). Mesmo `commonTest` do job
+      # "testes-comuns" (patrimônio bruto/dívidas/líquido, distribuição por classe em basis points,
+      # `ConversorMonetario`, redaction de `ItemPatrimonial`) — sem este passo, "roda igual nos dois
+      # lados" era garantido só pelo `verifyArchitecture` (ausência de API de plataforma), nunca por
+      # execução real do runtime Kotlin/Native no iOS.
+      - name: Testar regras patrimoniais canônicas no simulador iOS (commonTest compartilhado)
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            :shared:core:model:iosSimulatorArm64Test \
+            :shared:domain:patrimonio:iosSimulatorArm64Test
 
       # Só o link real de framework (iosSimulatorArm64) exige host macOS; em Linux essa tarefa
       # fica SKIPPED. Roda isolado antes do Xcode pra falhar rápido e com log específico se o

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ConversorMonetarioTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/ConversorMonetarioTest.kt
@@ -50,4 +50,18 @@ class ConversorMonetarioTest {
         assertEquals(1_500L, ConversorMonetario.paraQuantidadeMilesimos("1,5"))
         assertEquals(1_234L, ConversorMonetario.paraQuantidadeMilesimos("1,234"))
     }
+
+    @Test
+    fun paraCentavos_valorAcimaDoLimiteDeLong_retornaNuloEmVezDeEstourar() {
+        // 30 dígitos: nenhum valor patrimonial real chega perto disso, mas o texto digitado é
+        // entrada de usuário não confiável — precisa falhar como "inválido" (null), nunca lançar
+        // exceção de overflow do `Long.toLong()`.
+        assertNull(ConversorMonetario.paraCentavos("1".repeat(30)))
+    }
+
+    @Test
+    fun paraCentavos_zero_naoRetornaNuloERepresentaZeroCentavos() {
+        assertEquals(0L, ConversorMonetario.paraCentavos("0"))
+        assertEquals(0L, ConversorMonetario.paraCentavos("0,00"))
+    }
 }

--- a/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/CalculoPatrimonioTest.kt
+++ b/aplicativo/shared/domain/patrimonio/src/commonTest/kotlin/io/savro/domain/patrimonio/calculo/CalculoPatrimonioTest.kt
@@ -93,6 +93,64 @@ class CalculoPatrimonioTest {
     }
 
     @Test
+    fun resumo_multiplasDividas_somaTodasAsDividas() {
+        val itens = listOf(
+            item("conta", TipoItemPatrimonial.CONTA, 200_000),
+            item("divida-cartao", TipoItemPatrimonial.DIVIDA, -30_000),
+            item("divida-financiamento", TipoItemPatrimonial.DIVIDA, -70_000),
+        )
+        val total = CalculoPatrimonio.resumo(itens).totaisPorMoeda.single()
+
+        assertEquals(200_000L, total.brutoCentavos)
+        assertEquals(100_000L, total.dividasCentavos)
+        assertEquals(100_000L, total.liquidoCentavos)
+    }
+
+    @Test
+    fun resumo_brutoIgualADividas_liquidoExatamenteZero() {
+        val itens = listOf(
+            item("conta", TipoItemPatrimonial.CONTA, 50_000),
+            item("divida", TipoItemPatrimonial.DIVIDA, -50_000),
+        )
+        val total = CalculoPatrimonio.resumo(itens).totaisPorMoeda.single()
+
+        assertEquals(50_000L, total.brutoCentavos)
+        assertEquals(50_000L, total.dividasCentavos)
+        assertEquals(0L, total.liquidoCentavos)
+    }
+
+    @Test
+    fun resumo_itemComValorZero_entraNoBrutoSemAlterarLiquido() {
+        val itens = listOf(
+            item("conta", TipoItemPatrimonial.CONTA, 100_000),
+            item("zerado", TipoItemPatrimonial.OUTRO, 0),
+        )
+        val total = CalculoPatrimonio.resumo(itens).totaisPorMoeda.single()
+
+        assertEquals(100_000L, total.brutoCentavos)
+        assertEquals(0L, total.dividasCentavos)
+        assertEquals(100_000L, total.liquidoCentavos)
+    }
+
+    @Test
+    fun resumo_valoresGrandes_somaSemOverflowSilencioso() {
+        // R$ 999.999.999,99 por item — ordem de grandeza muito acima de qualquer patrimônio real,
+        // usada só para provar que a soma de poucos itens grandes não estoura silenciosamente
+        // dentro da faixa em que este app opera (Long tem margem folgada até ~R$ 92 quatrilhões).
+        val valorGrandeCentavos = 99_999_999_999L
+        val itens = listOf(
+            item("bem-a", TipoItemPatrimonial.BEM, valorGrandeCentavos),
+            item("bem-b", TipoItemPatrimonial.BEM, valorGrandeCentavos),
+            item("divida-grande", TipoItemPatrimonial.DIVIDA, -valorGrandeCentavos),
+        )
+        val total = CalculoPatrimonio.resumo(itens).totaisPorMoeda.single()
+
+        assertEquals(valorGrandeCentavos * 2, total.brutoCentavos)
+        assertEquals(valorGrandeCentavos, total.dividasCentavos)
+        assertEquals(valorGrandeCentavos, total.liquidoCentavos)
+    }
+
+    @Test
     fun distribuicaoPorClasse_somaExatamente10000BasisPointsApesarDeDivisaoNaoExata() {
         // 3 itens de 1000 centavos cada => 1/3 exato não existe em base 10 — testa o método do
         // maior resto sem nunca usar Double.
@@ -125,6 +183,36 @@ class CalculoPatrimonioTest {
         assertTrue(
             CalculoPatrimonio.distribuicaoPorClasse(listOf(item("divida", TipoItemPatrimonial.DIVIDA, -1_000))).isEmpty(),
         )
+    }
+
+    @Test
+    fun distribuicaoPorClasse_itemComValorZero_naoGeraFatiaPropria() {
+        val itens = listOf(
+            item("conta", TipoItemPatrimonial.CONTA, 100_000),
+            item("zerado", TipoItemPatrimonial.OUTRO, 0),
+        )
+        val distribuicao = CalculoPatrimonio.distribuicaoPorClasse(itens).single()
+        assertEquals(1, distribuicao.fatias.size)
+        assertEquals(TipoItemPatrimonial.CONTA, distribuicao.fatias.single().tipo)
+    }
+
+    @Test
+    fun distribuicaoPorClasse_multiplasMoedas_umaDistribuicaoIndependentePorMoeda() {
+        val itens = listOf(
+            item("conta-brl", TipoItemPatrimonial.CONTA, 100_000, moeda = "BRL"),
+            item("cripto-brl", TipoItemPatrimonial.CRIPTO, 100_000, moeda = "BRL"),
+            item("conta-usd", TipoItemPatrimonial.CONTA, 50_000, moeda = "USD"),
+        )
+        val distribuicoes = CalculoPatrimonio.distribuicaoPorClasse(itens)
+
+        assertEquals(2, distribuicoes.size)
+        val brl = distribuicoes.single { it.moeda == "BRL" }
+        assertEquals(2, brl.fatias.size)
+        assertEquals(10_000, brl.fatias.sumOf { it.percentualBasisPoints })
+
+        val usd = distribuicoes.single { it.moeda == "USD" }
+        assertEquals(1, usd.fatias.size)
+        assertEquals(10_000, usd.fatias.single().percentualBasisPoints)
     }
 
     @Test


### PR DESCRIPTION
## Objetivo

Auditar e consolidar em `commonMain` (Kotlin Multiplatform) as regras patrimoniais canônicas
(patrimônio bruto, dívidas, líquido, distribuição por classe, conversão monetária), conforme
issue #179.

Closes #179 — todos os critérios de aceite estão atendidos e confirmados por CI verde neste SHA
(ver "Justificativa objetiva" no final).

## Inventário (auditoria, antes de qualquer mudança de código)

| Regra | Implementação atual | Fonte canônica | Está em commonMain? | Cobertura de teste | Ação necessária |
|---|---|---|---|---|---|
| Patrimônio bruto (soma de ativos, sem dívidas) | `CalculoPatrimonio.resumo()` — `aplicativo/shared/domain/patrimonio/.../calculo/CalculoPatrimonio.kt` | #120 | Sim | `CalculoPatrimonioTest` (commonTest) | Nenhuma — já correta. Adicionados vetores de múltiplas dívidas/líquido zero/valor zero/valores grandes. |
| Dívidas (soma, sinal) | `CalculoPatrimonio.resumo()` — convenção: `valorCentavos` de item `DIVIDA` é sempre `<= 0` no modelo; `dividasCentavos` exposto é sempre `>= 0` (valor absoluto, nunca duplica sinal na tela) | #119 (`ItemPatrimonial`), #120 (`CalculoPatrimonio`) | Sim | `CalculoPatrimonioTest` | Nenhuma — adicionado vetor de múltiplas dívidas somadas |
| Patrimônio líquido = bruto − dívidas | `TotalPorMoeda.liquidoCentavos` (é a soma direta de `valorCentavos`, garantida pela convenção de sinal) | #120 | Sim | `CalculoPatrimonioTest` | Nenhuma — adicionado vetor de líquido exatamente zero |
| Distribuição percentual por categoria | `CalculoPatrimonio.distribuicaoPorClasse()` — basis points inteiros (0..10000), método do maior resto, sem `Double` | #120 | Sim | `CalculoPatrimonioTest` | Nenhuma — adicionados vetores de item com valor zero e múltiplas moedas |
| Carteira vazia / total zero | `ResumoPatrimonio.VAZIO`; `distribuicaoPorClasse` retorna lista vazia se `somaTotal <= 0` | #120 | Sim | `CalculoPatrimonioTest` | Nenhuma |
| Itens arquivados fora dos totais | `resumo`/`distribuicaoPorClasse`/`itensQuePrecisamAtualizacao`/`dataUltimaAtualizacao` todos fazem `filterNot { it.arquivado }` | #119 | Sim | `CalculoPatrimonioTest` | Nenhuma |
| Múltiplas moedas — sem conversão cambial silenciosa | `resumo()` agrupa por `moeda`; `consolidavel = totais.size <= 1`; nunca soma moedas diferentes | #120 | Sim | `CalculoPatrimonioTest` | Nenhuma — adicionado vetor de `distribuicaoPorClasse` com múltiplas moedas (só havia cobertura em `resumo`) |
| Tipo monetário (evitar Double) | `Long` em centavos (`valorCentavos`) em todo o domínio; `quantidadeMilesimos` escalado por 1000 | #180 (convenção original), #119 (`ItemPatrimonial`) | Sim | `RedacaoModeloPatrimonialTest`, testes de `CalculoPatrimonio`/`ConversorMonetario` | Nenhuma — modelo já determinístico, não trocado |
| Conversão texto ↔ centavos (parse/format) | `ConversorMonetario` — aceita `,`/`.`, separador de milhar, negativo | #119 | Sim | `ConversorMonetarioTest` | Nenhuma — adicionados vetores de overflow gracioso (retorna `null`, nunca lança) e zero explícito |
| Validação de sinal por tipo (dívida <=0, demais >=0) | `ValidadorItemPatrimonial.validar()` + `ServicoPatrimonio.ajustarValor()` (mesma regra nos dois pontos de entrada) | #119 | Sim | `ValidadorItemPatrimonialTest` | Nenhuma |
| Ordenação (nome/valor) | `List<ItemPatrimonial>.ordenarPor()` | #120 | Sim | `OrdenacaoItensPatrimoniaisTest` | Nenhuma |
| Filtro (texto/tipo/arquivado) | `FiltroItensPatrimoniais.aplicar()` | #119 | Sim | `FiltroItensPatrimoniaisTest` | Nenhuma |
| Datas em regra de domínio (formatação, sem fuso local) | `FormatadorData` (algoritmo civil de Hinnant, UTC, sem `kotlinx-datetime`) | #121 | Sim | `FormatadorDataTest` | Nenhuma |
| Item desatualizado (90 dias) | `CalculoPatrimonio.itensQuePrecisamAtualizacao()` | #120 | Sim | `CalculoPatrimonioTest` | Nenhuma |
| Máscara de privacidade de valor | `ApresentacaoValor` | #120 | Sim | `ApresentacaoValorTest` | Nenhuma |
| Exportação CSV | `ExportadorCsv` — só serializa itens já calculados (`ConversorMonetario`/`FormatadorData`), nunca recalcula total | #121 | Sim | `ExportadorCsvTest` | Nenhuma — confirmado que não há fórmula paralela |
| Backup/restauração | `SerializadorBackup` — só (de)serializa campos de `ItemPatrimonial`/`AjusteValorItem`, nunca recalcula total | #121 | Sim | testes de `core:backup` + vetores de referência Android/iOS | Nenhuma |
| Consumo pelas telas (Home/Patrimônio/Detalhe) | `HomeScreens.kt` usa `CalculoPatrimonio.resumo/distribuicaoPorClasse/itensQuePrecisamAtualizacao/dataUltimaAtualizacao` diretamente; `PatrimonioScreens`/`DetalheScreens` só exibem `item.valorCentavos` individual via `ConversorMonetario`, nenhum recompute | #120 | Sim (`:shared:app` é Compose Multiplatform, `commonMain`) | Cobertura indireta via `CalculoPatrimonioTest` (motor único) | Nenhuma — nenhum composable, Android ou iOS host duplica cálculo |
| Fronteira arquitetural (nada de plataforma no domínio) | `verifyArchitecture` (Gradle task, roda em todo PR) — bloqueia `android.*`, `platform.*`, `androidx.*`, cinterop, rede etc. em `commonMain`/módulos puros | #117/#193 | Enforced automaticamente | `VerifyArchitectureFunctionalTest` | Nenhuma |
| CI executa commonTest em todos os targets suportados | `:shared:domain:patrimonio` e `:shared:core:model` já declaravam `iosArm64()`/`iosSimulatorArm64()` desde a #119, mas nenhum job de CI compilava ou testava esses módulos em iOS — só Android/JVM | — | N/A (lacuna de CI, não de domínio) | Nenhuma até esta PR | Corrigida nesta PR — ver abaixo |

## O que já existia (entregue indiretamente pelas #118-#121)

Toda a lógica de cálculo patrimonial pura já estava em `commonMain`, sem duplicação em
Android/iOS/composables, com sinal de dívida único e sem `Double`. A #179 previa "portar" essas
regras, mas o trabalho de porte já tinha sido feito como parte da implementação das próprias
telas (#119 cadastro manual, #120 experiência principal, #121 backup/CSV) — a issue não foi
fechada na época porque não havia auditoria formal nem verificação de execução do `commonTest`
em todos os targets.

## O que precisou ser feito nesta rodada

1. Vetores de caracterização faltando em `CalculoPatrimonioTest`/`ConversorMonetarioTest`:
   múltiplas dívidas somadas, patrimônio líquido exatamente zero, item com valor zero (bruto e
   distribuição), distribuição por classe com múltiplas moedas, valores grandes sem overflow
   silencioso, overflow gracioso do parser de texto (retorna `null`, nunca lança exceção), zero
   explícito no `ConversorMonetario`.
2. Lacuna real de CI: `:shared:domain:patrimonio` e `:shared:core:model` compilam para iOS
   desde sempre (targets declarados no `build.gradle.kts`), mas nunca tiveram seu `commonTest`
   executado em iOS — só via `androidUnitTest` (JVM). Adicionado:
   - job `ios-compilacao-linux`: `compileKotlinIosArm64`/`compileKotlinIosSimulatorArm64` para os
     dois módulos (fail-fast barato, sem precisar de runner macOS);
   - job `ios-xcode-macos`: `iosSimulatorArm64Test` real para os dois módulos, no simulador.

## Divergências encontradas

Nenhuma divergência de regra entre Android e iOS ou entre telas — não havia cópia paralela de
cálculo em nenhum composable, ViewModel, host Android/iOS, exportação ou backup. Não houve
necessidade de teste de caracterização de "duas implementações divergentes" porque só existe
uma implementação. A única divergência real era de cobertura de CI (módulo compila mas não
era testado em iOS), não de comportamento.

## Compatibilidade

Nenhum modelo, schema de banco, formato de backup (`*.savrobackup`) ou CSV foi alterado. Somente
testes e configuração de CI foram tocados.

## Resultados dos testes

- commonTest via Android/JVM (`:shared:core:model`, `:shared:core:testing`,
  `:shared:core:designsystem`, `:shared:core:security`, `:shared:core:backup`,
  `:shared:domain:patrimonio`, `:androidApp:testDevDebugUnitTest`): executado localmente,
  passou (inclui os novos vetores). `:shared:core:database:testDebugUnitTest` tem 4 falhas
  pré-existentes em `master`, reproduzidas também antes desta mudança — ambiente
  Robolectric/Windows, módulo fora do escopo desta issue (#180/#118); não regredido por esta PR.
- `verifyArchitecture` / `verifyDesignSystemTokens` / `verifyNoNetworkAccess`: passou
  localmente.
- `:androidApp:assembleDevDebug`: build passou localmente.
- iOS: compilação klib (`compileKotlinIosSimulatorArm64`) de `:shared:core:model` e
  `:shared:domain:patrimonio` validada localmente (compila em host não-macOS). Execução real de
  `iosSimulatorArm64Test` rodou no runner macOS do GitHub Actions e passou:
  `:shared:core:model:iosSimulatorArm64Test` e `:shared:domain:patrimonio:iosSimulatorArm64Test`
  (log confirma `linkDebugTestIosSimulatorArm64` + execução no simulador, não é teste "SKIPPED").
  Run: https://github.com/gmmattey/esquilo-wallet/actions/runs/30413680152
  (job "Link do framework e build do Xcode (runner macOS)":
  https://github.com/gmmattey/esquilo-wallet/actions/runs/30413680152/job/90455348491).

## Status final da CI desta PR (todos os jobs)

- Fronteira KMP e tokens do design system: pass (3m2s)
- Testes de commonTest e módulos compartilhados (inclui `:shared:core:database` na CI Linux,
  sem as falhas vistas localmente no Windows): pass (5m38s)
- Lint e build de desenvolvimento Android: pass (7m17s)
- Compilação dos klibs iOS (sem link, sem macOS) — agora inclui `:shared:core:model` e
  `:shared:domain:patrimonio`: pass (2m39s)
- Link do framework e build do Xcode (runner macOS) — agora inclui
  `iosSimulatorArm64Test` de `:shared:core:model`/`:shared:domain:patrimonio`: pass (10m51s)
- Typecheck, testes e build (workflow legado do monorepo TS, sem relação com `aplicativo/`):
  pass (47s)

Run completo: https://github.com/gmmattey/esquilo-wallet/actions/runs/30413680152

## Riscos restantes

- Módulo `:shared:core:database` tem falha de teste pré-existente em ambiente Windows local
  (Robolectric) — não investigado nesta PR por estar fora do escopo da #179; roda limpo na CI
  Linux historicamente, então não é um risco real de regressão, só ruído do ambiente local do
  agente.
- Nenhum risco novo introduzido por esta PR além do já existente na base.

## Justificativa objetiva — fechar #179

Todos os critérios de aceite do passo 12 estão atendidos, confirmados por evidência real (não
suposição):

- Regras ficam em `commonMain`: sim (`:shared:domain:patrimonio`, `:shared:core:model`).
- Testes determinísticos ficam em `commonTest`: sim, incluindo os vetores adicionados nesta PR.
- Android e iOS consomem a mesma implementação, sem cópias paralelas: sim — confirmado por
  execução real (não só compilação) do mesmo `commonTest` em Android/JVM e no simulador iOS
  (run https://github.com/gmmattey/esquilo-wallet/actions/runs/30413680152), e por inspeção de
  código (nenhum composable, ViewModel, host ou exportação recalcula).
- Nenhuma API de plataforma ou infraestrutura aparece no domínio: sim, `verifyArchitecture`
  passou (task automatizada, roda em todo PR).
- Cada regra aponta sua origem e limitações: sim, documentado em KDoc apontando #119/#120/#121 e
  em `documentacao/arquitetura/formato-csv-savro.md`/`formato-savrobackup.md`.
- CI verde no SHA final: sim, todos os 6 jobs (incluindo os 2 novos passos de iOS) passaram no
  SHA `1674cf033eb325b453a946ec48a525b592fe645a`.

A única lacuna real encontrada na auditoria — módulos com regra canônica declarando alvo iOS mas
sem execução de teste real nesse alvo em nenhum job de CI — foi corrigida nesta própria PR, e a
correção já está verificada em CI real, não apenas planejada.
