### PR TITLE
fix(#226): detectar disponibilidade real de biometria

### DIFF
--- a/.github/workflows/aplicativo-ci.yml
+++ b/.github/workflows/aplicativo-ci.yml
@@ -257,6 +257,15 @@ jobs:
             :shared:core:database:compileKotlinIosSimulatorArm64 \
             :shared:core:database:iosSimulatorArm64Test
 
+      # Máquina de estados do cofre e mapeamento de LocalAuthentication (#118/#226) — nunca rodava
+      # em nenhum job de CI: "ios-compilacao-linux" só compilava (compileKotlinIosX), sem executar
+      # nenhum teste; este é o primeiro ponto real de execução do `commonTest`/`iosTest` de
+      # `:shared:core:security` no simulador iOS. Cobre `GerenciadorCofreTest`,
+      # `DecisaoOpcaoProtecaoTest` (commonTest) e `AutenticadorBiometricoIOSTest` (iosTest, mapeamento
+      # de `LAError` com `NSError` reais, sem sensor físico).
+      - name: Testar máquina de estados do cofre e biometria no simulador iOS
+        run: ./gradlew --no-daemon --stacktrace :shared:core:security:iosSimulatorArm64Test
+
       # Evidência de interoperabilidade Android <-> iOS da #121 (critério de aceite, não opcional).
       # É o MESMO `commonTest` que o job "testes-comuns" roda na JVM: o arquivo de referência
       # `VetoresDeReferencia.ARQUIVO_HEX` foi gerado pela implementação Android e aqui precisa

--- a/aplicativo/shared/app/src/commonMain/composeResources/values/strings.xml
+++ b/aplicativo/shared/app/src/commonMain/composeResources/values/strings.xml
@@ -26,7 +26,15 @@
     <string name="cofre_credencial_invalida_titulo">Não foi possível confirmar</string>
     <string name="cofre_credencial_invalida_mensagem">A biometria ou o código informado não conferem. Tente de novo.</string>
     <string name="cofre_biometria_indisponivel_titulo">Proteção indisponível</string>
-    <string name="cofre_biometria_indisponivel_mensagem">Não há biometria nem código de dispositivo configurados. Configure a proteção do aparelho ou continue sem proteção.</string>
+    <string name="cofre_biometria_indisponivel_mensagem">Não foi possível checar a proteção do aparelho agora. Tente de novo ou continue sem proteção.</string>
+    <string name="cofre_biometria_sem_hardware_titulo">Sem biometria neste aparelho</string>
+    <string name="cofre_biometria_sem_hardware_mensagem">Este aparelho não tem sensor de biometria. Use o código do aparelho ou continue sem proteção.</string>
+    <string name="cofre_biometria_nao_configurada_titulo">Biometria não cadastrada</string>
+    <string name="cofre_biometria_nao_configurada_mensagem">Cadastre uma biometria nas configurações do aparelho, use o código do aparelho, ou continue sem proteção.</string>
+    <string name="cofre_biometria_sem_credencial_titulo">Sem código do aparelho</string>
+    <string name="cofre_biometria_sem_credencial_mensagem">Defina um código, PIN ou padrão nas configurações do aparelho para usar essa proteção. Por enquanto, continue sem proteção.</string>
+    <string name="cofre_biometria_bloqueio_permanente_titulo">Biometria bloqueada</string>
+    <string name="cofre_biometria_bloqueio_permanente_mensagem">Muitas tentativas erradas bloquearam a biometria. Confirme o código do aparelho para liberar de novo, ou continue sem proteção.</string>
     <string name="cofre_bloqueio_temporario_titulo">Bloqueado temporariamente</string>
     <string name="cofre_bloqueio_temporario_mensagem">Muitas tentativas. Aguarde um momento e tente de novo.</string>
     <string name="cofre_chave_invalidada_titulo">A proteção do aparelho mudou</string>

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/AjustesScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/AjustesScreens.kt
@@ -43,6 +43,8 @@ import io.savro.designsystem.componentes.SavroTextField
 import io.savro.designsystem.componentes.SavroWarningBanner
 import io.savro.designsystem.tema.SavroThemeTokens
 import io.savro.domain.patrimonio.calculo.FormatadorData
+import io.savro.security.DecisaoOpcaoProtecao
+import io.savro.security.DisponibilidadeBiometria
 import io.savro.security.GerenciadorCofre
 import io.savro.security.PoliticaProtecao
 import kotlinx.coroutines.launch
@@ -474,8 +476,15 @@ private fun PassoExportarCsv(
 private fun SecaoProtecao(gerenciador: GerenciadorCofre) {
     val escopo = rememberCoroutineScope()
     var politica by remember { mutableStateOf<PoliticaProtecao?>(null) }
+    // Ativar aqui usa a mesma combinação padrão de `ativarProtecao()` (biometria OU credencial do
+    // aparelho) — checa essa combinação antes de oferecer o botão como habilitado (#226): nunca
+    // deixa "Ativar proteção" aparecer clicável para depois falhar no primeiro desbloqueio.
+    var disponibilidadeParaAtivar by remember { mutableStateOf<DisponibilidadeBiometria?>(null) }
 
-    LaunchedEffect(gerenciador) { politica = gerenciador.politicaAtual() }
+    LaunchedEffect(gerenciador) {
+        politica = gerenciador.politicaAtual()
+        disponibilidadeParaAtivar = gerenciador.disponibilidadeBiometrica(permitirCredencialDispositivo = true)
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
         SavroText(stringResource(Res.string.configuracao_protecao_titulo), style = SavroTextStyle.Title)
@@ -484,8 +493,17 @@ private fun SecaoProtecao(gerenciador: GerenciadorCofre) {
             null -> Unit
             PoliticaProtecao.Nenhuma -> {
                 SavroText(stringResource(Res.string.configuracao_protecao_estado_desativada))
+                val disponibilidade = disponibilidadeParaAtivar
+                val podeAtivar = disponibilidade?.let(DecisaoOpcaoProtecao::habilitada) ?: false
+                if (disponibilidade != null && !podeAtivar) {
+                    SavroText(
+                        stringResource(mensagemIndisponibilidade(disponibilidade)),
+                        style = SavroTextStyle.BodySmall,
+                    )
+                }
                 SavroButton(
                     label = stringResource(Res.string.configuracao_protecao_botao_ativar),
+                    enabled = podeAtivar,
                     onClick = {
                         escopo.launch {
                             gerenciador.ativarProtecao()

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreOnboarding.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreOnboarding.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,6 +46,8 @@ import io.savro.designsystem.componentes.SavroText
 import io.savro.designsystem.componentes.SavroTextStyle
 import io.savro.designsystem.componentes.SavroWarningBanner
 import io.savro.designsystem.tema.SavroThemeTokens
+import io.savro.security.DecisaoOpcaoProtecao
+import io.savro.security.DisponibilidadeBiometria
 import io.savro.security.GerenciadorCofre
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
@@ -133,16 +136,37 @@ private enum class OpcaoProtecao { Biometria, Credencial, SemBloqueio }
  * `permitirCredencialDispositivo = false`, Credencial do aparelho ==
  * `permitirCredencialDispositivo = true` — nenhum estado de domínio novo foi criado.
  *
- * Pendência real (registrada, não resolvida aqui): não há contrato disponível para checar se o
- * aparelho tem biometria configurada sem mudar `GerenciadorCofre`/`AutenticadorBiometrico` — as
- * três opções ficam sempre habilitadas, diferente do protótipo ("sem biometria → opção
- * desabilitada, com nota").
+ * Disponibilidade real (#226): checa `GerenciadorCofre.disponibilidadeBiometrica` para as duas
+ * combinações assim que a tela entra em composição (nunca mostra prompt) — cada opção só fica
+ * marcável quando o aparelho está pronto para ela agora, com uma nota explicando o motivo real
+ * quando não está (nunca "cadastre sua biometria" para um problema que não é esse).
  */
 @Composable
 private fun TelaEscolherProtecao(gerenciador: GerenciadorCofre, aoConcluir: () -> Unit) {
     val escopo = rememberCoroutineScope()
     var opcao by remember { mutableStateOf(OpcaoProtecao.Biometria) }
     var confirmouResponsabilidade by remember { mutableStateOf(false) }
+    var disponibilidadeBiometria by remember { mutableStateOf<DisponibilidadeBiometria?>(null) }
+    var disponibilidadeCredencial by remember { mutableStateOf<DisponibilidadeBiometria?>(null) }
+
+    LaunchedEffect(gerenciador) {
+        disponibilidadeBiometria = gerenciador.disponibilidadeBiometrica(permitirCredencialDispositivo = false)
+        disponibilidadeCredencial = gerenciador.disponibilidadeBiometrica(permitirCredencialDispositivo = true)
+
+        // Se a opção pré-selecionada (Biometria, valor inicial) não estiver pronta, cai para a
+        // primeira que estiver — nunca deixa "Continuar" seguir com uma opção que sabidamente vai
+        // falhar no primeiro desbloqueio.
+        val biometriaOk = disponibilidadeBiometria == DisponibilidadeBiometria.Disponivel
+        val credencialOk = disponibilidadeCredencial == DisponibilidadeBiometria.Disponivel
+        if (opcao == OpcaoProtecao.Biometria && !biometriaOk) {
+            opcao = if (credencialOk) OpcaoProtecao.Credencial else OpcaoProtecao.SemBloqueio
+        }
+    }
+
+    // Enquanto a checagem não voltou, nenhuma opção protegida é oferecida como pronta — evita
+    // piscar "habilitada" e depois desabilitar assim que o resultado real chega.
+    val biometriaHabilitada = disponibilidadeBiometria?.let(DecisaoOpcaoProtecao::habilitada) ?: false
+    val credencialHabilitada = disponibilidadeCredencial?.let(DecisaoOpcaoProtecao::habilitada) ?: false
 
     Column(
         modifier = Modifier.fillMaxSize().padding(SavroThemeTokens.spacing.md),
@@ -155,11 +179,19 @@ private fun TelaEscolherProtecao(gerenciador: GerenciadorCofre, aoConcluir: () -
             label = stringResource(Res.string.protecao_opcao_biometria),
             selected = opcao == OpcaoProtecao.Biometria,
             onClick = { opcao = OpcaoProtecao.Biometria },
+            enabled = biometriaHabilitada,
+            supportingText = disponibilidadeBiometria
+                ?.takeUnless { it == DisponibilidadeBiometria.Disponivel }
+                ?.let { stringResource(mensagemIndisponibilidade(it)) },
         )
         SavroRadioOptionCard(
             label = stringResource(Res.string.protecao_opcao_credencial),
             selected = opcao == OpcaoProtecao.Credencial,
             onClick = { opcao = OpcaoProtecao.Credencial },
+            enabled = credencialHabilitada,
+            supportingText = disponibilidadeCredencial
+                ?.takeUnless { it == DisponibilidadeBiometria.Disponivel }
+                ?.let { stringResource(mensagemIndisponibilidade(it)) },
         )
         SavroRadioOptionCard(
             label = stringResource(Res.string.protecao_opcao_sem_bloqueio),

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreScreens.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/CofreScreens.kt
@@ -14,8 +14,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
 import io.savro.app.recursos.Res
-import io.savro.app.recursos.cofre_biometria_indisponivel_mensagem
-import io.savro.app.recursos.cofre_biometria_indisponivel_titulo
 import io.savro.app.recursos.cofre_bloqueio_temporario_mensagem
 import io.savro.app.recursos.cofre_bloqueio_temporario_titulo
 import io.savro.app.recursos.cofre_botao_continuar_sem_protecao
@@ -39,6 +37,7 @@ import io.savro.designsystem.componentes.SavroState
 import io.savro.designsystem.componentes.SavroStatePanel
 import io.savro.designsystem.tema.SavroThemeTokens
 import io.savro.domain.patrimonio.ServicoPatrimonio
+import io.savro.security.DecisaoOpcaoProtecao
 import io.savro.security.EstadoCofre
 import io.savro.security.GerenciadorCofre
 import kotlinx.coroutines.launch
@@ -71,14 +70,18 @@ internal fun TelaCofre(
             action = { BotaoTentarNovamente(gerenciador) },
         )
 
-        EstadoCofre.BiometriaIndisponivel -> SavroStatePanel(
+        is EstadoCofre.BiometriaIndisponivel -> SavroStatePanel(
             state = SavroState.Error,
-            title = stringResource(Res.string.cofre_biometria_indisponivel_titulo),
-            message = stringResource(Res.string.cofre_biometria_indisponivel_mensagem),
+            title = stringResource(tituloIndisponibilidade(atual.motivo)),
+            message = stringResource(mensagemIndisponibilidade(atual.motivo)),
             icon = SavroIcon.EstadoErro,
             action = {
                 Column(verticalArrangement = Arrangement.spacedBy(SavroThemeTokens.spacing.sm)) {
-                    BotaoTentarNovamente(gerenciador)
+                    // "Tentar novamente" só aparece quando o motivo é transitório (#226) — sem
+                    // hardware/cadastro/credencial/bloqueio permanente não mudam sozinhos com um
+                    // novo clique, e insistir sem explicar isso é o tipo de UX que a auditoria
+                    // pediu para eliminar.
+                    if (DecisaoOpcaoProtecao.permiteTentarNovamente(atual.motivo)) BotaoTentarNovamente(gerenciador)
                     SavroButton(
                         label = stringResource(Res.string.cofre_botao_continuar_sem_protecao),
                         onClick = { escopo.launch { gerenciador.removerProtecao(); gerenciador.tentarNovamente() } },

--- a/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/TextosBiometria.kt
+++ b/aplicativo/shared/app/src/commonMain/kotlin/io/savro/app/TextosBiometria.kt
@@ -1,0 +1,48 @@
+package io.savro.app
+
+import io.savro.app.recursos.Res
+import io.savro.app.recursos.cofre_biometria_bloqueio_permanente_mensagem
+import io.savro.app.recursos.cofre_biometria_bloqueio_permanente_titulo
+import io.savro.app.recursos.cofre_biometria_indisponivel_mensagem
+import io.savro.app.recursos.cofre_biometria_indisponivel_titulo
+import io.savro.app.recursos.cofre_biometria_nao_configurada_mensagem
+import io.savro.app.recursos.cofre_biometria_nao_configurada_titulo
+import io.savro.app.recursos.cofre_biometria_sem_credencial_mensagem
+import io.savro.app.recursos.cofre_biometria_sem_credencial_titulo
+import io.savro.app.recursos.cofre_biometria_sem_hardware_mensagem
+import io.savro.app.recursos.cofre_biometria_sem_hardware_titulo
+import io.savro.app.recursos.cofre_bloqueio_temporario_mensagem
+import io.savro.app.recursos.cofre_bloqueio_temporario_titulo
+import io.savro.security.DisponibilidadeBiometria
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * Título e mensagem coerentes com a causa real de indisponibilidade (#226, "hardware ausente não
+ * sugere cadastre sua biometria") — usado tanto no painel de estado do cofre (`CofreScreens.kt`)
+ * quanto na explicação inline de cada opção desabilitada (`CofreOnboarding.kt`, `AjustesScreens.kt`).
+ * A decisão de habilitar/desabilitar/permitir fallback é de [io.savro.security.DecisaoOpcaoProtecao]
+ * (commonMain de `:shared:core:security`, sem Compose) — aqui só a tradução para string.
+ */
+internal fun tituloIndisponibilidade(motivo: DisponibilidadeBiometria): StringResource = when (motivo) {
+    DisponibilidadeBiometria.SemHardware -> Res.string.cofre_biometria_sem_hardware_titulo
+    DisponibilidadeBiometria.NaoConfigurada -> Res.string.cofre_biometria_nao_configurada_titulo
+    DisponibilidadeBiometria.SemCredencialDispositivo -> Res.string.cofre_biometria_sem_credencial_titulo
+    DisponibilidadeBiometria.BloqueadaPermanentemente -> Res.string.cofre_biometria_bloqueio_permanente_titulo
+    is DisponibilidadeBiometria.BloqueadaTemporariamente -> Res.string.cofre_bloqueio_temporario_titulo
+    DisponibilidadeBiometria.Disponivel,
+    DisponibilidadeBiometria.Indisponivel,
+    is DisponibilidadeBiometria.ErroDesconhecido,
+    -> Res.string.cofre_biometria_indisponivel_titulo
+}
+
+internal fun mensagemIndisponibilidade(motivo: DisponibilidadeBiometria): StringResource = when (motivo) {
+    DisponibilidadeBiometria.SemHardware -> Res.string.cofre_biometria_sem_hardware_mensagem
+    DisponibilidadeBiometria.NaoConfigurada -> Res.string.cofre_biometria_nao_configurada_mensagem
+    DisponibilidadeBiometria.SemCredencialDispositivo -> Res.string.cofre_biometria_sem_credencial_mensagem
+    DisponibilidadeBiometria.BloqueadaPermanentemente -> Res.string.cofre_biometria_bloqueio_permanente_mensagem
+    is DisponibilidadeBiometria.BloqueadaTemporariamente -> Res.string.cofre_bloqueio_temporario_mensagem
+    DisponibilidadeBiometria.Disponivel,
+    DisponibilidadeBiometria.Indisponivel,
+    is DisponibilidadeBiometria.ErroDesconhecido,
+    -> Res.string.cofre_biometria_indisponivel_mensagem
+}

--- a/aplicativo/shared/core/security/src/androidMain/kotlin/io/savro/security/AutenticadorBiometricoAndroid.kt
+++ b/aplicativo/shared/core/security/src/androidMain/kotlin/io/savro/security/AutenticadorBiometricoAndroid.kt
@@ -31,20 +31,26 @@ class AutenticadorBiometricoAndroid(
         if (atividadeAtual === atividade) atividadeAtual = null
     }
 
-    override suspend fun disponibilidade(): DisponibilidadeBiometria {
+    override suspend fun disponibilidade(permitirCredencialDispositivo: Boolean): DisponibilidadeBiometria {
         val gerenciador = BiometricManager.from(context)
-        val autenticadores = BiometricManager.Authenticators.BIOMETRIC_STRONG or
-            BiometricManager.Authenticators.DEVICE_CREDENTIAL
-        return when (gerenciador.canAuthenticate(autenticadores)) {
-            BiometricManager.BIOMETRIC_SUCCESS -> DisponibilidadeBiometria.Disponivel
-            BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
-            BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE,
-            -> DisponibilidadeBiometria.SemHardware
-            BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> DisponibilidadeBiometria.NaoConfigurada
-            else -> DisponibilidadeBiometria.TemporariamenteIndisponivel(
-                "Biometria temporariamente indisponível (código ${gerenciador.canAuthenticate(autenticadores)})",
-            )
+        val autenticadores = if (permitirCredencialDispositivo) {
+            BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+        } else {
+            BiometricManager.Authenticators.BIOMETRIC_STRONG
         }
+        val status = gerenciador.canAuthenticate(autenticadores)
+
+        // BIOMETRIC_ERROR_NO_HARDWARE/HW_UNAVAILABLE, na combinação com DEVICE_CREDENTIAL, também é
+        // o que o BiometricManager devolve quando o problema real não é o sensor, e sim o aparelho
+        // não ter nenhum código/PIN/padrão configurado — checa a credencial isolada pra diferenciar
+        // as duas mensagens (nunca sugerir "cadastre biometria" quando o problema é outro, #226).
+        val statusApenasCredencial = if (permitirCredencialDispositivo) {
+            gerenciador.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+        } else {
+            null
+        }
+
+        return mapearDisponibilidade(status, permitirCredencialDispositivo, statusApenasCredencial)
     }
 
     override suspend fun autenticar(
@@ -93,15 +99,14 @@ class AutenticadorBiometricoAndroid(
         }
     }
 
-    private fun mapearErro(codigo: Int, mensagem: String): ResultadoAutenticacao = when (codigo) {
+    internal fun mapearErro(codigo: Int, mensagem: String): ResultadoAutenticacao = when (codigo) {
         BiometricPrompt.ERROR_USER_CANCELED,
         BiometricPrompt.ERROR_NEGATIVE_BUTTON,
         BiometricPrompt.ERROR_CANCELED,
         -> ResultadoAutenticacao.Cancelado
         BiometricPrompt.ERROR_LOCKOUT ->
             ResultadoAutenticacao.BloqueioTemporario(System.currentTimeMillis() + BLOQUEIO_TEMPORARIO_PADRAO_MS)
-        BiometricPrompt.ERROR_LOCKOUT_PERMANENT ->
-            ResultadoAutenticacao.FalhaCredencial("Biometria bloqueada permanentemente pelo sistema: $mensagem")
+        BiometricPrompt.ERROR_LOCKOUT_PERMANENT -> ResultadoAutenticacao.BloqueioPermanente
         BiometricPrompt.ERROR_NO_BIOMETRICS,
         BiometricPrompt.ERROR_HW_UNAVAILABLE,
         BiometricPrompt.ERROR_HW_NOT_PRESENT,
@@ -113,4 +118,45 @@ class AutenticadorBiometricoAndroid(
     private companion object {
         const val BLOQUEIO_TEMPORARIO_PADRAO_MS = 30_000L
     }
+}
+
+/**
+ * Mapeamento puro dos códigos de `BiometricManager.canAuthenticate` (#226) — função de nível de
+ * topo (não depende de `Context`/instância) para ser testável direto, sem precisar simular
+ * hardware real via Robolectric (ver `AutenticadorBiometricoAndroidTest`).
+ *
+ * @param status resultado de `canAuthenticate` com a combinação de autenticadores efetivamente
+ *   pedida (biometria isolada, ou biometria + credencial).
+ * @param permitirCredencialDispositivo mesma combinação usada para obter [status].
+ * @param statusApenasCredencial resultado de `canAuthenticate(DEVICE_CREDENTIAL)` isolado, só
+ *   quando [permitirCredencialDispositivo] é `true` — usado para diferenciar "sem hardware
+ *   biométrico" de "sem credencial do aparelho nenhuma" (o Android devolve o mesmo código de erro
+ *   para os dois casos na combinação combinada).
+ */
+internal fun mapearDisponibilidade(
+    status: Int,
+    permitirCredencialDispositivo: Boolean,
+    statusApenasCredencial: Int?,
+): DisponibilidadeBiometria = when (status) {
+    BiometricManager.BIOMETRIC_SUCCESS -> DisponibilidadeBiometria.Disponivel
+
+    BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
+    BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE,
+    -> when {
+        !permitirCredencialDispositivo -> DisponibilidadeBiometria.SemHardware
+        statusApenasCredencial == BiometricManager.BIOMETRIC_SUCCESS -> DisponibilidadeBiometria.SemHardware
+        else -> DisponibilidadeBiometria.SemCredencialDispositivo
+    }
+
+    BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> DisponibilidadeBiometria.NaoConfigurada
+
+    // Atualização de segurança pendente é transitório e fora do controle do usuário dentro do
+    // app — mais próximo de "indisponível agora" do que de qualquer estado de configuração.
+    BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED -> DisponibilidadeBiometria.Indisponivel
+
+    BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED,
+    BiometricManager.BIOMETRIC_STATUS_UNKNOWN,
+    -> DisponibilidadeBiometria.ErroDesconhecido("BiometricManager retornou status $status")
+
+    else -> DisponibilidadeBiometria.ErroDesconhecido("Código de status desconhecido: $status")
 }

--- a/aplicativo/shared/core/security/src/androidUnitTest/kotlin/io/savro/security/AutenticadorBiometricoAndroidTest.kt
+++ b/aplicativo/shared/core/security/src/androidUnitTest/kotlin/io/savro/security/AutenticadorBiometricoAndroidTest.kt
@@ -1,6 +1,8 @@
 package io.savro.security
 
 import android.os.Build
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
 import androidx.fragment.app.FragmentActivity
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.test.runTest
@@ -9,13 +11,16 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 /**
  * [AutenticadorBiometricoAndroid] via Robolectric — sem hardware biométrico real (nenhum
  * emulador/dispositivo neste ambiente), então cobre o que é determinístico sem depender de um
- * diálogo real do sistema: disponibilidade em aparelho sem biometria configurada, e o
- * comportamento de segurança de nunca mostrar o prompt sem uma Activity vinculada.
+ * diálogo real do sistema: disponibilidade em aparelho sem biometria configurada, o comportamento
+ * de segurança de nunca mostrar o prompt sem uma Activity vinculada, e o mapeamento puro (#226)
+ * de todos os códigos relevantes de `BiometricManager.canAuthenticate`/`BiometricPrompt` — esses
+ * últimos não dependem de Robolectric simular hardware, só dos próprios constantes da lib.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
@@ -29,7 +34,8 @@ class AutenticadorBiometricoAndroidTest {
         // hardware) — o que este teste garante é que a chamada nunca lança exceção e sempre
         // resolve para um dos casos do contrato comum, não o comportamento de um aparelho real
         // sem biometria (isso exigiria device físico, fora do alcance deste ambiente).
-        autenticador.disponibilidade()
+        autenticador.disponibilidade(permitirCredencialDispositivo = true)
+        autenticador.disponibilidade(permitirCredencialDispositivo = false)
     }
 
     @Test
@@ -45,5 +51,118 @@ class AutenticadorBiometricoAndroidTest {
         val activity = Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
         autenticador.vincularAtividade(activity)
         autenticador.desvincularAtividade(activity)
+    }
+
+    // --- mapearDisponibilidade (#226): mapeia todos os retornos relevantes de canAuthenticate ---
+
+    @Test
+    fun mapearDisponibilidade_sucesso_viraDisponivel() {
+        assertEquals(
+            DisponibilidadeBiometria.Disponivel,
+            mapearDisponibilidade(BiometricManager.BIOMETRIC_SUCCESS, true, BiometricManager.BIOMETRIC_SUCCESS),
+        )
+    }
+
+    @Test
+    fun mapearDisponibilidade_semHardwareApenasBiometria_viraSemHardware() {
+        assertEquals(
+            DisponibilidadeBiometria.SemHardware,
+            mapearDisponibilidade(BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE, false, null),
+        )
+        assertEquals(
+            DisponibilidadeBiometria.SemHardware,
+            mapearDisponibilidade(BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE, false, null),
+        )
+    }
+
+    @Test
+    fun mapearDisponibilidade_semHardwareMasComCredencialDoAparelho_viraSemHardware() {
+        // Combinado permite credencial, checagem isolada de DEVICE_CREDENTIAL funciona — o
+        // problema real é só a ausência de sensor, não a ausência de credencial nenhuma.
+        assertEquals(
+            DisponibilidadeBiometria.SemHardware,
+            mapearDisponibilidade(
+                BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
+                true,
+                BiometricManager.BIOMETRIC_SUCCESS,
+            ),
+        )
+    }
+
+    @Test
+    fun mapearDisponibilidade_semHardwareESemCredencial_viraSemCredencialDispositivo() {
+        // Combinado permite credencial, mas a checagem isolada de DEVICE_CREDENTIAL também falha —
+        // o problema real é não haver nenhum código/PIN/padrão configurado no aparelho.
+        assertEquals(
+            DisponibilidadeBiometria.SemCredencialDispositivo,
+            mapearDisponibilidade(
+                BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
+                true,
+                BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
+            ),
+        )
+    }
+
+    @Test
+    fun mapearDisponibilidade_nenhumaBiometriaCadastrada_viraNaoConfigurada() {
+        assertEquals(
+            DisponibilidadeBiometria.NaoConfigurada,
+            mapearDisponibilidade(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED, true, BiometricManager.BIOMETRIC_SUCCESS),
+        )
+    }
+
+    @Test
+    fun mapearDisponibilidade_atualizacaoDeSegurancaPendente_viraIndisponivel() {
+        assertEquals(
+            DisponibilidadeBiometria.Indisponivel,
+            mapearDisponibilidade(BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED, true, null),
+        )
+    }
+
+    @Test
+    fun mapearDisponibilidade_codigosNaoSuportadosOuDesconhecidos_viraErroDesconhecido() {
+        assertIs<DisponibilidadeBiometria.ErroDesconhecido>(
+            mapearDisponibilidade(BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED, true, null),
+        )
+        assertIs<DisponibilidadeBiometria.ErroDesconhecido>(
+            mapearDisponibilidade(BiometricManager.BIOMETRIC_STATUS_UNKNOWN, true, null),
+        )
+        assertIs<DisponibilidadeBiometria.ErroDesconhecido>(mapearDisponibilidade(-999, true, null))
+    }
+
+    // --- mapearErro (#226): mapeia os erros terminais relevantes de BiometricPrompt ---
+
+    @Test
+    fun mapearErro_cancelamentoDoUsuario_naoViraFalhaDestrutiva() {
+        assertEquals(ResultadoAutenticacao.Cancelado, autenticador.mapearErro(BiometricPrompt.ERROR_USER_CANCELED, "cancelado"))
+        assertEquals(ResultadoAutenticacao.Cancelado, autenticador.mapearErro(BiometricPrompt.ERROR_NEGATIVE_BUTTON, "cancelado"))
+        assertEquals(ResultadoAutenticacao.Cancelado, autenticador.mapearErro(BiometricPrompt.ERROR_CANCELED, "cancelado"))
+    }
+
+    @Test
+    fun mapearErro_bloqueioTemporario_carregaHorarioFuturo() {
+        val resultado = autenticador.mapearErro(BiometricPrompt.ERROR_LOCKOUT, "bloqueado")
+        assertIs<ResultadoAutenticacao.BloqueioTemporario>(resultado)
+    }
+
+    @Test
+    fun mapearErro_bloqueioPermanente_viraBloqueioPermanente() {
+        assertEquals(
+            ResultadoAutenticacao.BloqueioPermanente,
+            autenticador.mapearErro(BiometricPrompt.ERROR_LOCKOUT_PERMANENT, "bloqueado para sempre"),
+        )
+    }
+
+    @Test
+    fun mapearErro_semBiometriaOuHardwareOuCredencial_viraIndisponivel() {
+        assertIs<ResultadoAutenticacao.Indisponivel>(autenticador.mapearErro(BiometricPrompt.ERROR_NO_BIOMETRICS, "x"))
+        assertIs<ResultadoAutenticacao.Indisponivel>(autenticador.mapearErro(BiometricPrompt.ERROR_HW_UNAVAILABLE, "x"))
+        assertIs<ResultadoAutenticacao.Indisponivel>(autenticador.mapearErro(BiometricPrompt.ERROR_HW_NOT_PRESENT, "x"))
+        assertIs<ResultadoAutenticacao.Indisponivel>(autenticador.mapearErro(BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL, "x"))
+    }
+
+    @Test
+    fun mapearErro_erroDesconhecido_viraFalhaCredencial() {
+        assertIs<ResultadoAutenticacao.FalhaCredencial>(autenticador.mapearErro(-999, "erro genérico"))
     }
 }

--- a/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/AutenticadorBiometrico.kt
+++ b/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/AutenticadorBiometrico.kt
@@ -8,8 +8,17 @@ package io.savro.security
  */
 interface AutenticadorBiometrico {
 
-    /** Consultado antes de mostrar o prompt, para decidir se vale a pena tentar. */
-    suspend fun disponibilidade(): DisponibilidadeBiometria
+    /**
+     * Consultado antes de mostrar o prompt (nunca dispara autenticação real —
+     * `BiometricManager.canAuthenticate`/`LAContext.canEvaluatePolicy`), para decidir se a opção
+     * deve aparecer habilitada e qual seria o desfecho de uma tentativa agora (#226).
+     *
+     * @param permitirCredencialDispositivo quando `true`, considera código/PIN/padrão do aparelho
+     *   como alternativa válida (mesma combinação que [autenticar] usaria); quando `false`, checa
+     *   só a biometria isolada. Chamado com os dois valores quando a UI precisa diferenciar as
+     *   opções "Biometria" e "Credencial do aparelho" (ver `TelaEscolherProtecao`).
+     */
+    suspend fun disponibilidade(permitirCredencialDispositivo: Boolean): DisponibilidadeBiometria
 
     /**
      * Mostra o prompt nativo e suspende até o usuário concluir, cancelar, ou o sistema recusar.

--- a/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/DecisaoOpcaoProtecao.kt
+++ b/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/DecisaoOpcaoProtecao.kt
@@ -1,0 +1,42 @@
+package io.savro.security
+
+/**
+ * Decisão pura (#226) sobre o que a UI faz com uma [DisponibilidadeBiometria] real — nenhuma
+ * plataforma decide isso, e nenhuma tela decide isso lendo o motivo "na unha" (evita 8 `when`
+ * espalhados divergindo aos poucos). Sem dependência de Compose/strings: mensagem final fica em
+ * `:shared:app`, aqui só o "sim/não" e "por quê" estruturado.
+ */
+object DecisaoOpcaoProtecao {
+
+    /** A opção só aparece marcável (rádio habilitado, botão habilitado) quando está pronta agora. */
+    fun habilitada(disponibilidade: DisponibilidadeBiometria): Boolean =
+        disponibilidade == DisponibilidadeBiometria.Disponivel
+
+    /**
+     * "Tentar novamente" só faz sentido quando o motivo é transitório — sem hardware, sem
+     * cadastro, sem credencial do aparelho ou bloqueio permanente não mudam sozinhos só porque o
+     * usuário apertou um botão de novo; exigem uma ação fora do app (ou, no caso do bloqueio
+     * permanente, confirmar a credencial do aparelho, que já é o próprio fluxo de autenticação).
+     */
+    fun permiteTentarNovamente(disponibilidade: DisponibilidadeBiometria): Boolean = when (disponibilidade) {
+        DisponibilidadeBiometria.SemHardware,
+        DisponibilidadeBiometria.NaoConfigurada,
+        DisponibilidadeBiometria.SemCredencialDispositivo,
+        DisponibilidadeBiometria.BloqueadaPermanentemente,
+        -> false
+
+        DisponibilidadeBiometria.Disponivel,
+        DisponibilidadeBiometria.Indisponivel,
+        is DisponibilidadeBiometria.BloqueadaTemporariamente,
+        is DisponibilidadeBiometria.ErroDesconhecido,
+        -> true
+    }
+
+    /**
+     * "Continuar sem proteção" precisa estar sempre presente quando a opção não está disponível —
+     * é a garantia de que uma detecção errada de biometria nunca deixa o usuário preso fora do
+     * cofre (regra do projeto, ver `GerenciadorCofre.removerProtecao`).
+     */
+    fun permiteContinuarSemProtecao(disponibilidade: DisponibilidadeBiometria): Boolean =
+        disponibilidade != DisponibilidadeBiometria.Disponivel
+}

--- a/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/DisponibilidadeBiometria.kt
+++ b/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/DisponibilidadeBiometria.kt
@@ -1,16 +1,49 @@
 package io.savro.security
 
-/** Resultado de checar se o aparelho consegue autenticar o usuário agora, antes de mostrar o prompt. */
+/**
+ * Resultado de checar, sem mostrar nenhum prompt, se o aparelho consegue autenticar o usuário
+ * agora com a combinação de autenticadores pedida (ver [AutenticadorBiometrico.disponibilidade]).
+ *
+ * Os 8 casos (#226) cobrem tudo que a decisão de UX precisa sem que nenhuma plataforma decida por
+ * conta própria se uma opção aparece, fica habilitada ou qual mensagem mostrar — Android e iOS só
+ * reportam o estado real (`BiometricManager.canAuthenticate`/`LAContext.canEvaluatePolicy`); quem
+ * decide fica em [DecisaoOpcaoProtecao] e na camada de UI (`:shared:app`).
+ */
 sealed class DisponibilidadeBiometria {
-    /** Biometria (ou, se permitido, credencial do dispositivo) pronta para uso. */
+
+    /** Os autenticadores pedidos estão prontos para uso agora — pode mostrar o prompt. */
     data object Disponivel : DisponibilidadeBiometria()
 
-    /** Aparelho não tem sensor biométrico nem código/PIN/padrão configurado — nada para checar. */
+    /** Aparelho não tem sensor biométrico nenhum (nem Face ID/Touch ID/impressão digital). */
     data object SemHardware : DisponibilidadeBiometria()
 
     /** Sensor existe, mas nenhuma biometria foi cadastrada pelo usuário no sistema. */
     data object NaoConfigurada : DisponibilidadeBiometria()
 
-    /** Indisponível agora por motivo transitório (atualização de segurança pendente, etc.). */
-    data class TemporariamenteIndisponivel(val motivo: String) : DisponibilidadeBiometria()
+    /**
+     * Aparelho não tem código/PIN/padrão/senha configurado no nível do sistema. Sem isso nem a
+     * credencial do dispositivo nem (no iOS) a própria biometria funcionam — a Apple exige
+     * passcode definido para cadastrar Face ID/Touch ID.
+     */
+    data object SemCredencialDispositivo : DisponibilidadeBiometria()
+
+    /**
+     * Sistema recusa novas tentativas até [tentarNovamenteEmEpocaMs] (quando conhecido) — sinal
+     * nativo (`BiometricPrompt.ERROR_LOCKOUT`), nunca uma contagem própria do Savro. `null` quando
+     * a plataforma sinaliza o bloqueio sem informar o horário exato de liberação.
+     */
+    data class BloqueadaTemporariamente(val tentarNovamenteEmEpocaMs: Long? = null) : DisponibilidadeBiometria()
+
+    /**
+     * Biometria bloqueada até o usuário confirmar a credencial do dispositivo pelo menos uma vez
+     * (`BiometricPrompt.ERROR_LOCKOUT_PERMANENT` no Android, `LAErrorBiometryLockout` no iOS — no
+     * iOS esse código não é temporizado, exige passcode para resetar).
+     */
+    data object BloqueadaPermanentemente : DisponibilidadeBiometria()
+
+    /** Indisponível agora por motivo transitório de sistema, sem causa mais específica conhecida. */
+    data object Indisponivel : DisponibilidadeBiometria()
+
+    /** Retorno da plataforma que não mapeia para nenhum caso acima — nunca finge "disponível". */
+    data class ErroDesconhecido(val motivo: String) : DisponibilidadeBiometria()
 }

--- a/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/EstadoCofre.kt
+++ b/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/EstadoCofre.kt
@@ -16,8 +16,12 @@ sealed class EstadoCofre {
     /** Biometria/credencial rejeitada pelo sistema nesta tentativa — usuário pode tentar de novo. */
     data class CredencialInvalida(val motivo: String) : EstadoCofre()
 
-    /** Nenhuma biometria/credencial de dispositivo configurada ou disponível para autenticar. */
-    data object BiometriaIndisponivel : EstadoCofre()
+    /**
+     * Biometria/credencial de dispositivo indisponível para autenticar agora — [motivo] é a causa
+     * real (#226, [DisponibilidadeBiometria]) para a UI escolher mensagem e fallback corretos, em
+     * vez de um aviso genérico que finge não saber por quê.
+     */
+    data class BiometriaIndisponivel(val motivo: DisponibilidadeBiometria) : EstadoCofre()
 
     /** Sistema recusa novas tentativas até [tentarNovamenteEmEpocaMs] (sinal nativo, não contagem própria). */
     data class BloqueioTemporario(val tentarNovamenteEmEpocaMs: Long) : EstadoCofre()

--- a/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/GerenciadorCofre.kt
+++ b/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/GerenciadorCofre.kt
@@ -72,29 +72,46 @@ class GerenciadorCofre(
     private suspend fun autenticarEAbrir() {
         val politica = preferencias.politicaProtecao() as? PoliticaProtecao.Ativada ?: return abrirCofre()
 
-        when (val disponibilidade = autenticador.disponibilidade()) {
-            DisponibilidadeBiometria.Disponivel -> {
-                when (
-                    val resultado = autenticador.autenticar(
-                        motivo = "Desbloquear o Savro",
-                        permitirCredencialDispositivo = politica.permitirCredencialDispositivo,
-                    )
-                ) {
-                    ResultadoAutenticacao.Sucesso -> abrirCofre()
-                    ResultadoAutenticacao.Cancelado ->
-                        _estado.value = EstadoCofre.CredencialInvalida("Autenticação cancelada")
-                    is ResultadoAutenticacao.FalhaCredencial ->
-                        _estado.value = EstadoCofre.CredencialInvalida(resultado.motivo)
-                    is ResultadoAutenticacao.BloqueioTemporario ->
-                        _estado.value = EstadoCofre.BloqueioTemporario(resultado.tentarNovamenteEmEpocaMs)
-                    is ResultadoAutenticacao.Indisponivel ->
-                        _estado.value = EstadoCofre.BiometriaIndisponivel
-                }
-            }
-            DisponibilidadeBiometria.SemHardware, DisponibilidadeBiometria.NaoConfigurada ->
-                _estado.value = EstadoCofre.BiometriaIndisponivel
-            is DisponibilidadeBiometria.TemporariamenteIndisponivel ->
-                _estado.value = EstadoCofre.ErroRecuperavel(disponibilidade.motivo)
+        // Checa a disponibilidade com a MESMA combinação de autenticadores que a política em uso
+        // vai pedir no prompt (#226) — checar sempre a combinação "com credencial" e depois tentar
+        // autenticar "sem credencial" (ou vice-versa) já produziu falsos positivos/negativos.
+        when (val disponibilidade = autenticador.disponibilidade(politica.permitirCredencialDispositivo)) {
+            DisponibilidadeBiometria.Disponivel -> autenticarComPrompt(politica)
+
+            is DisponibilidadeBiometria.BloqueadaTemporariamente ->
+                _estado.value = EstadoCofre.BloqueioTemporario(
+                    disponibilidade.tentarNovamenteEmEpocaMs
+                        ?: (relogio.agoraEmEpocaMs() + BLOQUEIO_TEMPORARIO_PADRAO_MS),
+                )
+
+            DisponibilidadeBiometria.SemHardware,
+            DisponibilidadeBiometria.NaoConfigurada,
+            DisponibilidadeBiometria.SemCredencialDispositivo,
+            DisponibilidadeBiometria.BloqueadaPermanentemente,
+            DisponibilidadeBiometria.Indisponivel,
+            is DisponibilidadeBiometria.ErroDesconhecido,
+            -> _estado.value = EstadoCofre.BiometriaIndisponivel(disponibilidade)
+        }
+    }
+
+    private suspend fun autenticarComPrompt(politica: PoliticaProtecao.Ativada) {
+        when (
+            val resultado = autenticador.autenticar(
+                motivo = "Desbloquear o Savro",
+                permitirCredencialDispositivo = politica.permitirCredencialDispositivo,
+            )
+        ) {
+            ResultadoAutenticacao.Sucesso -> abrirCofre()
+            ResultadoAutenticacao.Cancelado ->
+                _estado.value = EstadoCofre.CredencialInvalida("Autenticação cancelada")
+            is ResultadoAutenticacao.FalhaCredencial ->
+                _estado.value = EstadoCofre.CredencialInvalida(resultado.motivo)
+            is ResultadoAutenticacao.BloqueioTemporario ->
+                _estado.value = EstadoCofre.BloqueioTemporario(resultado.tentarNovamenteEmEpocaMs)
+            ResultadoAutenticacao.BloqueioPermanente ->
+                _estado.value = EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.BloqueadaPermanentemente)
+            is ResultadoAutenticacao.Indisponivel ->
+                _estado.value = EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.Indisponivel)
         }
     }
 
@@ -126,6 +143,14 @@ class GerenciadorCofre(
     fun reconhecerChaveInvalidada() {
         _estado.value = EstadoCofre.RestauracaoNecessaria
     }
+
+    /**
+     * Consultado pela UI (#226) antes de oferecer ou habilitar cada opção de proteção — nunca
+     * mostra prompt (`AutenticadorBiometrico.disponibilidade` só consulta o sistema). A UI decide
+     * mensagem e habilitação a partir do resultado via [DecisaoOpcaoProtecao], não direto aqui.
+     */
+    suspend fun disponibilidadeBiometrica(permitirCredencialDispositivo: Boolean): DisponibilidadeBiometria =
+        autenticador.disponibilidade(permitirCredencialDispositivo)
 
     /** Ativa a proteção — exige o cofre já desbloqueado (não é chamado durante o fluxo de desbloqueio). */
     suspend fun ativarProtecao(permitirCredencialDispositivo: Boolean = true) {
@@ -164,5 +189,15 @@ class GerenciadorCofre(
                 avaliarInicio()
             }
         }
+    }
+
+    private companion object {
+        /**
+         * Usado só quando [DisponibilidadeBiometria.BloqueadaTemporariamente] chega sem horário de
+         * liberação (a checagem de disponibilidade, diferente de uma tentativa real, nem sempre
+         * sabe o horário exato) — mesmo valor de fallback que Android usa para
+         * `BiometricPrompt.ERROR_LOCKOUT` em [ResultadoAutenticacao.BloqueioTemporario].
+         */
+        const val BLOQUEIO_TEMPORARIO_PADRAO_MS = 30_000L
     }
 }

--- a/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/ResultadoAutenticacao.kt
+++ b/aplicativo/shared/core/security/src/commonMain/kotlin/io/savro/security/ResultadoAutenticacao.kt
@@ -12,10 +12,19 @@ sealed class ResultadoAutenticacao {
 
     /**
      * O próprio sistema operacional bloqueou novas tentativas temporariamente (muitas falhas
-     * consecutivas) — sinal nativo de cada plataforma (`BiometricPrompt.ERROR_LOCKOUT` no Android,
-     * `LAErrorBiometryLockout` no iOS), nunca uma contagem própria do Savro.
+     * consecutivas) — sinal nativo (`BiometricPrompt.ERROR_LOCKOUT` no Android; no iOS não existe
+     * um equivalente temporizado real, ver [BloqueioPermanente]), nunca uma contagem própria do
+     * Savro.
      */
     data class BloqueioTemporario(val tentarNovamenteEmEpocaMs: Long) : ResultadoAutenticacao()
+
+    /**
+     * Biometria bloqueada até o usuário confirmar a credencial do dispositivo pelo menos uma vez
+     * (`BiometricPrompt.ERROR_LOCKOUT_PERMANENT` no Android, `LAErrorBiometryLockout` no iOS — o
+     * único código de bloqueio biométrico do iOS, sem contrapartida temporizada real, por isso
+     * mapeia para cá e não para [BloqueioTemporario]).
+     */
+    data object BloqueioPermanente : ResultadoAutenticacao()
 
     /** Biometria/credencial não disponível no momento da tentativa (ver [DisponibilidadeBiometria]). */
     data class Indisponivel(val motivo: String) : ResultadoAutenticacao()

--- a/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/DecisaoOpcaoProtecaoTest.kt
+++ b/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/DecisaoOpcaoProtecaoTest.kt
@@ -1,0 +1,51 @@
+package io.savro.security
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Cobre a decisão pura de UX (#226) sem nenhuma dependência de Compose/plataforma. */
+class DecisaoOpcaoProtecaoTest {
+
+    @Test
+    fun habilitada_somenteQuandoDisponivel() {
+        assertTrue(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.Disponivel))
+
+        assertFalse(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.SemHardware))
+        assertFalse(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.NaoConfigurada))
+        assertFalse(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.SemCredencialDispositivo))
+        assertFalse(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.BloqueadaPermanentemente))
+        assertFalse(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.Indisponivel))
+        assertFalse(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.BloqueadaTemporariamente()))
+        assertFalse(DecisaoOpcaoProtecao.habilitada(DisponibilidadeBiometria.ErroDesconhecido("x")))
+    }
+
+    @Test
+    fun permiteTentarNovamente_falsoParaMotivosQueNaoMudamSozinhos() {
+        assertFalse(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.SemHardware))
+        assertFalse(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.NaoConfigurada))
+        assertFalse(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.SemCredencialDispositivo))
+        assertFalse(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.BloqueadaPermanentemente))
+    }
+
+    @Test
+    fun permiteTentarNovamente_verdadeiroParaMotivosTransitorios() {
+        assertTrue(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.Disponivel))
+        assertTrue(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.Indisponivel))
+        assertTrue(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.BloqueadaTemporariamente()))
+        assertTrue(DecisaoOpcaoProtecao.permiteTentarNovamente(DisponibilidadeBiometria.ErroDesconhecido("x")))
+    }
+
+    @Test
+    fun permiteContinuarSemProtecao_verdadeiroParaTudoMenosDisponivel() {
+        assertFalse(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.Disponivel))
+
+        assertTrue(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.SemHardware))
+        assertTrue(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.NaoConfigurada))
+        assertTrue(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.SemCredencialDispositivo))
+        assertTrue(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.BloqueadaPermanentemente))
+        assertTrue(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.Indisponivel))
+        assertTrue(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.BloqueadaTemporariamente()))
+        assertTrue(DecisaoOpcaoProtecao.permiteContinuarSemProtecao(DisponibilidadeBiometria.ErroDesconhecido("x")))
+    }
+}

--- a/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/FakeAutenticadorBiometrico.kt
+++ b/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/FakeAutenticadorBiometrico.kt
@@ -9,8 +9,16 @@ class FakeAutenticadorBiometrico(
         private set
     var ultimoPermitirCredencialDispositivo: Boolean? = null
         private set
+    var vezesDisponibilidadeConsultada: Int = 0
+        private set
+    var ultimoPermitirCredencialDispositivoConsultado: Boolean? = null
+        private set
 
-    override suspend fun disponibilidade(): DisponibilidadeBiometria = disponibilidadeSimulada
+    override suspend fun disponibilidade(permitirCredencialDispositivo: Boolean): DisponibilidadeBiometria {
+        vezesDisponibilidadeConsultada += 1
+        ultimoPermitirCredencialDispositivoConsultado = permitirCredencialDispositivo
+        return disponibilidadeSimulada
+    }
 
     override suspend fun autenticar(motivo: String, permitirCredencialDispositivo: Boolean): ResultadoAutenticacao {
         vezesChamado += 1

--- a/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/GerenciadorCofreTest.kt
+++ b/aplicativo/shared/core/security/src/commonTest/kotlin/io/savro/security/GerenciadorCofreTest.kt
@@ -129,7 +129,159 @@ class GerenciadorCofreTest {
         gerenciador.iniciar()
         advanceUntilIdle()
 
-        assertEquals(EstadoCofre.BiometriaIndisponivel, gerenciador.estado.value)
+        assertEquals(
+            EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.NaoConfigurada),
+            gerenciador.estado.value,
+        )
+        assertEquals(0, c.autenticador.vezesChamado)
+    }
+
+    @Test
+    fun semHardwareBiometrico_viraBiometriaIndisponivelComMotivoEspecifico() = runTest {
+        val c = cenario(
+            autenticador = FakeAutenticadorBiometrico(disponibilidadeSimulada = DisponibilidadeBiometria.SemHardware),
+            preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada()),
+        )
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.SemHardware), gerenciador.estado.value)
+    }
+
+    @Test
+    fun semCredencialDeDispositivo_viraBiometriaIndisponivelComMotivoEspecifico() = runTest {
+        val c = cenario(
+            autenticador = FakeAutenticadorBiometrico(
+                disponibilidadeSimulada = DisponibilidadeBiometria.SemCredencialDispositivo,
+            ),
+            preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada()),
+        )
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(
+            EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.SemCredencialDispositivo),
+            gerenciador.estado.value,
+        )
+    }
+
+    @Test
+    fun biometriaBloqueadaPermanentemente_viraBiometriaIndisponivelComMotivoEspecifico() = runTest {
+        val c = cenario(
+            autenticador = FakeAutenticadorBiometrico(
+                disponibilidadeSimulada = DisponibilidadeBiometria.BloqueadaPermanentemente,
+            ),
+            preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada()),
+        )
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(
+            EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.BloqueadaPermanentemente),
+            gerenciador.estado.value,
+        )
+    }
+
+    @Test
+    fun disponibilidadeComErroDesconhecido_viraBiometriaIndisponivelComMotivoEspecifico() = runTest {
+        val c = cenario(
+            autenticador = FakeAutenticadorBiometrico(
+                disponibilidadeSimulada = DisponibilidadeBiometria.ErroDesconhecido("status inesperado"),
+            ),
+            preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada()),
+        )
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(
+            EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.ErroDesconhecido("status inesperado")),
+            gerenciador.estado.value,
+        )
+    }
+
+    @Test
+    fun bloqueioTemporarioDetectadoNaDisponibilidade_viraBloqueioTemporarioSemTentarAutenticar() = runTest {
+        val c = cenario(
+            autenticador = FakeAutenticadorBiometrico(
+                disponibilidadeSimulada = DisponibilidadeBiometria.BloqueadaTemporariamente(
+                    tentarNovamenteEmEpocaMs = 45_000L,
+                ),
+            ),
+            preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada()),
+        )
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(EstadoCofre.BloqueioTemporario(45_000L), gerenciador.estado.value)
+        // Já se sabe pela checagem de disponibilidade que vai falhar — nunca mostra o prompt.
+        assertEquals(0, c.autenticador.vezesChamado)
+    }
+
+    @Test
+    fun bloqueioTemporarioSemHorarioConhecido_usaFallbackAPartirDoRelogio() = runTest {
+        val c = cenario(
+            autenticador = FakeAutenticadorBiometrico(
+                disponibilidadeSimulada = DisponibilidadeBiometria.BloqueadaTemporariamente(
+                    tentarNovamenteEmEpocaMs = null,
+                ),
+            ),
+            preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada()),
+        )
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(EstadoCofre.BloqueioTemporario(30_000L), gerenciador.estado.value)
+    }
+
+    @Test
+    fun bloqueioPermanenteDuranteTentativaReal_viraBiometriaIndisponivelBloqueadaPermanentemente() = runTest {
+        val c = cenario(
+            autenticador = FakeAutenticadorBiometrico(resultadoSimulado = ResultadoAutenticacao.BloqueioPermanente),
+            preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada()),
+        )
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(
+            EstadoCofre.BiometriaIndisponivel(DisponibilidadeBiometria.BloqueadaPermanentemente),
+            gerenciador.estado.value,
+        )
+    }
+
+    @Test
+    fun disponibilidadeConsultadaComAMesmaPoliticaConfigurada() = runTest {
+        val c = cenario(preferencias = FakePreferenciasCofre(politica = PoliticaProtecao.Ativada(false)))
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        gerenciador.iniciar()
+        advanceUntilIdle()
+
+        assertEquals(1, c.autenticador.vezesDisponibilidadeConsultada)
+        assertEquals(false, c.autenticador.ultimoPermitirCredencialDispositivoConsultado)
+    }
+
+    @Test
+    fun disponibilidadeBiometricaExpostaParaUi_naoMostraPrompt() = runTest {
+        val c = cenario(autenticador = FakeAutenticadorBiometrico(disponibilidadeSimulada = DisponibilidadeBiometria.Disponivel))
+        val gerenciador = GerenciadorCofre(c.provedor, c.repositorio, c.autenticador, c.preferencias, c.relogio, this)
+
+        val resultado = gerenciador.disponibilidadeBiometrica(permitirCredencialDispositivo = true)
+
+        assertEquals(DisponibilidadeBiometria.Disponivel, resultado)
         assertEquals(0, c.autenticador.vezesChamado)
     }
 

--- a/aplicativo/shared/core/security/src/iosMain/kotlin/io/savro/security/AutenticadorBiometricoIOS.kt
+++ b/aplicativo/shared/core/security/src/iosMain/kotlin/io/savro/security/AutenticadorBiometricoIOS.kt
@@ -1,6 +1,7 @@
 package io.savro.security
 
 import kotlin.coroutines.resume
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.alloc
@@ -20,7 +21,6 @@ import platform.LocalAuthentication.LAErrorUserCancel
 import platform.LocalAuthentication.LAErrorUserFallback
 import platform.LocalAuthentication.LAPolicyDeviceOwnerAuthentication
 import platform.LocalAuthentication.LAPolicyDeviceOwnerAuthenticationWithBiometrics
-import platform.posix.time
 
 /**
  * [AutenticadorBiometrico] iOS: `LocalAuthentication`/`LAContext` (Face ID, Touch ID ou código do
@@ -32,25 +32,23 @@ import platform.posix.time
 @OptIn(ExperimentalForeignApi::class)
 class AutenticadorBiometricoIOS : AutenticadorBiometrico {
 
-    override suspend fun disponibilidade(): DisponibilidadeBiometria = memScoped {
-        val contexto = LAContext()
-        val erro = alloc<ObjCObjectVar<NSError?>>()
-        val podeAvaliar = contexto.canEvaluatePolicy(
-            LAPolicyDeviceOwnerAuthentication,
-            error = erro.ptr,
-        )
-        if (podeAvaliar) return@memScoped DisponibilidadeBiometria.Disponivel
+    @OptIn(BetaInteropApi::class)
+    override suspend fun disponibilidade(permitirCredencialDispositivo: Boolean): DisponibilidadeBiometria =
+        memScoped {
+            // Instância nova a cada checagem (padrão recomendado pela Apple, mesma regra de
+            // `autenticar`) — `canEvaluatePolicy` nunca dispara prompt, só consulta o sistema.
+            val contexto = LAContext()
+            val erro = alloc<ObjCObjectVar<NSError?>>()
+            val politica = if (permitirCredencialDispositivo) {
+                LAPolicyDeviceOwnerAuthentication
+            } else {
+                LAPolicyDeviceOwnerAuthenticationWithBiometrics
+            }
+            val podeAvaliar = contexto.canEvaluatePolicy(politica, error = erro.ptr)
+            if (podeAvaliar) return@memScoped DisponibilidadeBiometria.Disponivel
 
-        when (erro.value?.code) {
-            LAErrorBiometryNotAvailable, LAErrorPasscodeNotSet -> DisponibilidadeBiometria.SemHardware
-            LAErrorBiometryNotEnrolled -> DisponibilidadeBiometria.NaoConfigurada
-            LAErrorBiometryLockout ->
-                DisponibilidadeBiometria.TemporariamenteIndisponivel("Biometria temporariamente bloqueada pelo sistema")
-            else -> DisponibilidadeBiometria.TemporariamenteIndisponivel(
-                erro.value?.localizedDescription ?: "Status de biometria desconhecido",
-            )
+            mapearDisponibilidade(erro.value)
         }
-    }
 
     override suspend fun autenticar(
         motivo: String,
@@ -73,18 +71,37 @@ class AutenticadorBiometricoIOS : AutenticadorBiometrico {
         }
     }
 
-    private fun mapearErro(erro: NSError?): ResultadoAutenticacao = when (erro?.code) {
+    internal fun mapearErro(erro: NSError?): ResultadoAutenticacao = when (erro?.code) {
         LAErrorUserCancel, LAErrorSystemCancel, LAErrorAppCancel, LAErrorUserFallback ->
             ResultadoAutenticacao.Cancelado
-        LAErrorBiometryLockout -> ResultadoAutenticacao.BloqueioTemporario(
-            time(null) * 1000L + BLOQUEIO_TEMPORARIO_PADRAO_MS,
-        )
+        // O iOS não tem um "ERROR_LOCKOUT" temporizado equivalente ao do Android — o único código
+        // de bloqueio biométrico (LAErrorBiometryLockout) exige o usuário confirmar a credencial
+        // do aparelho pra resetar, o que é semanticamente um bloqueio permanente, não temporário
+        // (achado da auditoria #226 — a versão anterior mapeava isso como 30s fixos, incorreto).
+        LAErrorBiometryLockout -> ResultadoAutenticacao.BloqueioPermanente
         LAErrorBiometryNotAvailable, LAErrorBiometryNotEnrolled, LAErrorPasscodeNotSet ->
             ResultadoAutenticacao.Indisponivel(erro?.localizedDescription ?: "Biometria indisponível")
         else -> ResultadoAutenticacao.FalhaCredencial(erro?.localizedDescription ?: "Falha de autenticação")
     }
+}
 
-    private companion object {
-        const val BLOQUEIO_TEMPORARIO_PADRAO_MS = 30_000L
-    }
+/**
+ * Mapeamento puro de [NSError.code] de `LAContext.canEvaluatePolicy` (#226) — função de nível de
+ * topo, testável direto com instâncias de `NSError` reais em `iosTest`
+ * (`AutenticadorBiometricoIOSTest`), sem precisar de sensor físico nem mock de `LAContext`.
+ */
+internal fun mapearDisponibilidade(erro: NSError?): DisponibilidadeBiometria = when (erro?.code) {
+    // No iOS, sem passcode configurado nem biometria funciona (Face ID/Touch ID exigem passcode
+    // definido) — LAErrorPasscodeNotSet é sempre a causa raiz "sem credencial do aparelho", não
+    // "sem hardware biométrico", mesmo quando a checagem pedida foi só biometria (#226: nunca
+    // sugerir "cadastre sua biometria" quando o problema real é a ausência de passcode).
+    LAErrorPasscodeNotSet -> DisponibilidadeBiometria.SemCredencialDispositivo
+    LAErrorBiometryNotAvailable -> DisponibilidadeBiometria.SemHardware
+    LAErrorBiometryNotEnrolled -> DisponibilidadeBiometria.NaoConfigurada
+    // Ver comentário em `mapearErro`: no iOS o único código de lockout biométrico se comporta como
+    // bloqueio permanente (exige credencial do aparelho pra resetar), nunca temporizado.
+    LAErrorBiometryLockout -> DisponibilidadeBiometria.BloqueadaPermanentemente
+    else -> DisponibilidadeBiometria.ErroDesconhecido(
+        erro?.localizedDescription ?: "Código de status desconhecido: ${erro?.code}",
+    )
 }

--- a/aplicativo/shared/core/security/src/iosTest/kotlin/io/savro/security/AutenticadorBiometricoIOSTest.kt
+++ b/aplicativo/shared/core/security/src/iosTest/kotlin/io/savro/security/AutenticadorBiometricoIOSTest.kt
@@ -1,0 +1,100 @@
+package io.savro.security
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import platform.Foundation.NSError
+import platform.LocalAuthentication.LAErrorAppCancel
+import platform.LocalAuthentication.LAErrorAuthenticationFailed
+import platform.LocalAuthentication.LAErrorBiometryLockout
+import platform.LocalAuthentication.LAErrorBiometryNotAvailable
+import platform.LocalAuthentication.LAErrorBiometryNotEnrolled
+import platform.LocalAuthentication.LAErrorDomain
+import platform.LocalAuthentication.LAErrorPasscodeNotSet
+import platform.LocalAuthentication.LAErrorSystemCancel
+import platform.LocalAuthentication.LAErrorUserCancel
+import platform.LocalAuthentication.LAErrorUserFallback
+
+/**
+ * Mapeamento de `LAError`/políticas (#226) — usa instâncias reais de `NSError` com cada código de
+ * `LAError`, nunca um sensor físico nem um `LAContext` real (só o mapeamento puro é exercitado
+ * aqui; `AutenticadorBiometricoIOS.disponibilidade`/`autenticar`, que chamam a API real do
+ * sistema, dependem do job `ios-xcode-macos` da CI pra validação de integração — ver docstring da
+ * classe). Roda em `iosArm64Test`/`iosSimulatorArm64Test`, sem exigir device físico.
+ */
+class AutenticadorBiometricoIOSTest {
+
+    private val autenticador = AutenticadorBiometricoIOS()
+
+    private fun erro(codigo: Long) = NSError(domain = LAErrorDomain, code = codigo, userInfo = null)
+
+    // --- mapearDisponibilidade ---
+
+    @Test
+    fun mapearDisponibilidade_passcodeNaoDefinido_viraSemCredencialDispositivo() {
+        assertEquals(DisponibilidadeBiometria.SemCredencialDispositivo, mapearDisponibilidade(erro(LAErrorPasscodeNotSet)))
+    }
+
+    @Test
+    fun mapearDisponibilidade_biometriaIndisponivel_viraSemHardware() {
+        assertEquals(DisponibilidadeBiometria.SemHardware, mapearDisponibilidade(erro(LAErrorBiometryNotAvailable)))
+    }
+
+    @Test
+    fun mapearDisponibilidade_biometriaNaoCadastrada_viraNaoConfigurada() {
+        assertEquals(DisponibilidadeBiometria.NaoConfigurada, mapearDisponibilidade(erro(LAErrorBiometryNotEnrolled)))
+    }
+
+    @Test
+    fun mapearDisponibilidade_biometriaBloqueada_viraBloqueadaPermanentemente() {
+        // No iOS, LAErrorBiometryLockout exige confirmar a credencial do aparelho pra resetar —
+        // nunca temporizado, por isso não mapeia para BloqueadaTemporariamente (ver comentário na
+        // implementação).
+        assertEquals(DisponibilidadeBiometria.BloqueadaPermanentemente, mapearDisponibilidade(erro(LAErrorBiometryLockout)))
+    }
+
+    @Test
+    fun mapearDisponibilidade_codigoNaoMapeado_viraErroDesconhecido() {
+        assertIs<DisponibilidadeBiometria.ErroDesconhecido>(mapearDisponibilidade(erro(LAErrorAuthenticationFailed)))
+    }
+
+    @Test
+    fun mapearDisponibilidade_semErro_viraErroDesconhecidoSemFingirDisponivel() {
+        // `disponibilidade()` só chama este mapeamento quando `canEvaluatePolicy` já retornou
+        // `false` — um `erro` nulo aqui não deveria acontecer na prática, mas o mapeamento nunca
+        // finge sucesso mesmo nesse caso extremo.
+        assertIs<DisponibilidadeBiometria.ErroDesconhecido>(mapearDisponibilidade(null))
+    }
+
+    // --- mapearErro (autenticar) ---
+
+    @Test
+    fun mapearErro_cancelamentoDoUsuario_naoViraFalhaDestrutiva() {
+        assertEquals(ResultadoAutenticacao.Cancelado, autenticador.mapearErro(erro(LAErrorUserCancel)))
+        assertEquals(ResultadoAutenticacao.Cancelado, autenticador.mapearErro(erro(LAErrorSystemCancel)))
+        assertEquals(ResultadoAutenticacao.Cancelado, autenticador.mapearErro(erro(LAErrorAppCancel)))
+        assertEquals(ResultadoAutenticacao.Cancelado, autenticador.mapearErro(erro(LAErrorUserFallback)))
+    }
+
+    @Test
+    fun mapearErro_biometriaBloqueada_viraBloqueioPermanente() {
+        assertEquals(ResultadoAutenticacao.BloqueioPermanente, autenticador.mapearErro(erro(LAErrorBiometryLockout)))
+    }
+
+    @Test
+    fun mapearErro_semBiometriaOuPasscode_viraIndisponivel() {
+        assertIs<ResultadoAutenticacao.Indisponivel>(autenticador.mapearErro(erro(LAErrorBiometryNotAvailable)))
+        assertIs<ResultadoAutenticacao.Indisponivel>(autenticador.mapearErro(erro(LAErrorBiometryNotEnrolled)))
+        assertIs<ResultadoAutenticacao.Indisponivel>(autenticador.mapearErro(erro(LAErrorPasscodeNotSet)))
+    }
+
+    @Test
+    fun mapearErro_falhaDeCredencial_viraFalhaCredencial() {
+        assertIs<ResultadoAutenticacao.FalhaCredencial>(autenticador.mapearErro(erro(LAErrorAuthenticationFailed)))
+    }
+
+    @Test
+    fun mapearErro_semErro_naoLancaExcecao() {
+        assertIs<ResultadoAutenticacao.FalhaCredencial>(autenticador.mapearErro(null))
+    }
+}

--- a/documentacao/arquitetura/validacoes/226-disponibilidade-biometria.md
+++ b/documentacao/arquitetura/validacoes/226-disponibilidade-biometria.md
@@ -1,0 +1,143 @@
+# 226 — disponibilidade real de biometria (Android + iOS)
+
+- **Issue:** [#226](https://github.com/gmmattey/esquilo-wallet/issues/226)
+- **Predecessora:** #118 (`:shared:core:security`, `documentacao/arquitetura/validacoes/118-cofre-local-e-desbloqueio.md`)
+  — este documento registra o que #226 corrigiu por cima do que #118 já tinha entregue, não repete
+  o que já estava lá.
+
+## Achado da auditoria (o que motivou a issue)
+
+`CofreOnboarding.kt` (tela "Proteja seu cofre") documentava a própria lacuna no código:
+
+> "Pendência real (registrada, não resolvida aqui): não há contrato disponível para checar se o
+> aparelho tem biometria configurada sem mudar `GerenciadorCofre`/`AutenticadorBiometrico` — as
+> três opções ficam sempre habilitadas, diferente do protótipo."
+
+Ou seja: as opções "Biometria" e "Credencial do aparelho" apareciam sempre marcáveis, mesmo em um
+aparelho sem sensor, sem biometria cadastrada ou sem PIN/senha configurado — o usuário só descobria
+que a proteção não funcionava na primeira tentativa real de desbloqueio (`EstadoCofre.BiometriaIndisponivel`,
+sem motivo nenhum anexado, então a mensagem era sempre genérica).
+
+Dois bugs reais de mapeamento também apareceram na auditoria do lado iOS (não hipotéticos —
+encontrados lendo `LAContext`/`LAError` contra a documentação da Apple):
+
+1. `LAErrorPasscodeNotSet` era mapeado para `SemHardware` — sugeria "sem sensor" quando o problema
+   real era "sem código do aparelho configurado" (mensagem incoerente com a causa, item explícito
+   da auditoria pedida na issue).
+2. `LAErrorBiometryLockout` era mapeado como bloqueio **temporário** de 30s fixos
+   (`time(null) * 1000L + 30_000L`). A documentação da Apple para esse código é clara: o bloqueio
+   só é resetado confirmando a credencial do aparelho, não por tempo — o equivalente correto é
+   `ERROR_LOCKOUT_PERMANENT` do Android, não `ERROR_LOCKOUT`. Corrigido nos dois lugares que faziam
+   esse mapeamento (`disponibilidade()` e `autenticar()`).
+
+| Plataforma | Detecção atual (antes) | Problema | API correta | Ação |
+|---|---|---|---|---|
+| Android | `BiometricManager.canAuthenticate(STRONG\|DEVICE_CREDENTIAL)` único, sem diferenciar causa | `SemHardware` e "sem PIN/senha nenhum" retornavam o mesmo código de erro (`NO_HARDWARE`), UI não distinguia | `canAuthenticate` chamado também isolado por `DEVICE_CREDENTIAL` para diferenciar as duas causas | `mapearDisponibilidade` (novo, puro, testável) |
+| Android | `ERROR_LOCKOUT_PERMANENT` mapeado para `FalhaCredencial` (texto livre) | Não distinguível de uma senha errada comum — UI não sabia oferecer o fallback certo | `ResultadoAutenticacao.BloqueioPermanente` (novo caso) | `mapearErro` corrigido |
+| iOS | `LAErrorPasscodeNotSet` → `SemHardware` | Mensagem incoerente ("sem sensor" quando falta é PIN/senha) | `LAErrorPasscodeNotSet` → `SemCredencialDispositivo` | `mapearDisponibilidade` (novo, puro, testável) |
+| iOS | `LAErrorBiometryLockout` → bloqueio **temporário** de 30s fixos | Semanticamente errado — a Apple exige confirmar a credencial do aparelho para resetar, não é temporizado | `LAErrorBiometryLockout` → `BloqueadaPermanentemente`/`ResultadoAutenticacao.BloqueioPermanente` | `mapearDisponibilidade`/`mapearErro` corrigidos |
+| Ambas | `DisponibilidadeBiometria` com 4 casos (`Disponivel`/`SemHardware`/`NaoConfigurada`/`TemporariamenteIndisponivel(String)`) | Não cobria "sem credencial do aparelho", "bloqueada permanentemente", "erro desconhecido" — UI não conseguia diferenciar causa nem decidir fallback | Modelo de 8 casos, sem `String` livre nos casos determinísticos | `DisponibilidadeBiometria.kt` reescrito |
+| `:shared:app` | `TelaEscolherProtecao`/`SecaoProtecao` nunca consultavam disponibilidade real | Opção "Biometria"/"Credencial do aparelho"/"Ativar proteção" sempre habilitada, mesmo indisponível | `GerenciadorCofre.disponibilidadeBiometrica(permitirCredencialDispositivo)` (novo, nunca mostra prompt) | `CofreOnboarding.kt`/`AjustesScreens.kt` atualizados |
+
+## Modelo compartilhado (`commonMain`)
+
+`DisponibilidadeBiometria` (`:shared:core:security`) passou de 4 para 8 casos: `Disponivel`,
+`SemHardware`, `NaoConfigurada`, `SemCredencialDispositivo` (novo), `BloqueadaTemporariamente`
+(novo, com horário opcional — a checagem de disponibilidade nem sempre sabe o horário exato, ao
+contrário de uma tentativa real), `BloqueadaPermanentemente` (novo), `Indisponivel` (novo, genérico
+transitório) e `ErroDesconhecido` (novo, com motivo — nunca finge "disponível" para um código não
+mapeado).
+
+`AutenticadorBiometrico.disponibilidade()` passou a receber `permitirCredencialDispositivo: Boolean`
+— a mesma checagem de disponibilidade tem que refletir exatamente a combinação de autenticadores
+que a política em uso vai pedir (checar sempre a combinação "com credencial" e depois tentar
+autenticar "sem credencial" já produzia falso positivo/negativo). A UI chama duas vezes (uma para
+cada valor) quando precisa diferenciar as opções "Biometria" e "Credencial do aparelho" — nunca
+mostra prompt, só consulta o sistema (`BiometricManager.canAuthenticate`/`LAContext.canEvaluatePolicy`).
+
+`DecisaoOpcaoProtecao` (novo, `:shared:core:security`, sem Compose/plataforma) centraliza a decisão
+pura: `habilitada()`, `permiteTentarNovamente()`, `permiteContinuarSemProtecao()` — nenhuma tela
+decide isso "na unha" com `when` espalhados. Testado isoladamente em `DecisaoOpcaoProtecaoTest`.
+
+`EstadoCofre.BiometriaIndisponivel` deixou de ser `data object` e passou a `data class(motivo:
+DisponibilidadeBiometria)` — a UI do painel de erro (`CofreScreens.kt`) usa o motivo para escolher
+título, mensagem e se oferece "Tentar novamente" (via `DecisaoOpcaoProtecao.permiteTentarNovamente`).
+"Continuar sem proteção" continua sempre presente nesse painel — garantia herdada da #118 de que o
+usuário nunca fica preso fora do cofre por causa de detecção errada de biometria.
+
+`GerenciadorCofre.disponibilidadeBiometrica(permitirCredencialDispositivo)` (novo, público) expõe a
+checagem pura para a UI sem vazar `AutenticadorBiometrico` para fora do módulo.
+
+## Android
+
+`AutenticadorBiometricoAndroid.disponibilidade()` reescrito: continua usando só `BIOMETRIC_STRONG`
+(e `DEVICE_CREDENTIAL` quando a política permite) — `BIOMETRIC_WEAK` deliberadamente fora, igual
+antes, por não haver decisão de produto pedindo essa combinação. O mapeamento puro
+(`mapearDisponibilidade`, função de nível de topo, sem depender de `Context`) cobre todos os
+retornos relevantes de `canAuthenticate`: sucesso, sem hardware, sem cadastro, atualização de
+segurança pendente, não suportado, status desconhecido — e diferencia "sem hardware" de "sem
+credencial do aparelho nenhuma" checando `DEVICE_CREDENTIAL` isolado quando a combinação
+`STRONG|DEVICE_CREDENTIAL` falha (o Android devolve o mesmo código de erro para os dois casos).
+
+`mapearErro` (erros terminais de `BiometricPrompt`) ganhou `ERROR_LOCKOUT_PERMANENT` →
+`ResultadoAutenticacao.BloqueioPermanente` (era `FalhaCredencial` com texto livre).
+
+Testado via Robolectric (`AutenticadorBiometricoAndroidTest`, 15 casos) — como o ambiente não tem
+hardware/emulador real, `mapearDisponibilidade`/`mapearErro` são funções puras exercitadas
+diretamente com os próprios constantes de `BiometricManager`/`BiometricPrompt`, sem precisar
+simular um aparelho físico.
+
+## iOS
+
+`AutenticadorBiometricoIOS.disponibilidade()` reescrito: `canEvaluatePolicy` (nunca dispara prompt)
+com `LAPolicyDeviceOwnerAuthenticationWithBiometrics` (biometria isolada) ou
+`LAPolicyDeviceOwnerAuthentication` (biometria ou passcode), conforme o parâmetro — cada checagem
+usa uma `LAContext()` nova (padrão recomendado pela Apple, mesma regra já seguida por `autenticar`).
+
+`mapearDisponibilidade`/`mapearErro` viraram funções de nível de topo/`internal`, puras, recebendo
+`NSError?` — testáveis com instâncias reais de `NSError(domain: LAErrorDomain, code:, userInfo:
+nil)` sem sensor físico nem mock de `LAContext`.
+
+Nenhuma SPI privada da Apple foi usada (regra do projeto) — só `LocalAuthentication` público, os
+mesmos símbolos já em uso desde a #118.
+
+**Novidade estrutural:** o módulo ganhou source set `iosTest` (`src/iosTest/kotlin/...`,
+`AutenticadorBiometricoIOSTest.kt`) — não existia nenhum antes no repo (nem em `:shared:core:backup`,
+que também tem `iosMain`). Funciona sem alterar `build.gradle.kts` graças ao "default hierarchy
+template" do Kotlin Multiplatform (ativo desde 1.9.20; o projeto está em 2.3.10), que já conecta
+`iosMain`/`iosTest` a `iosArm64`/`iosSimulatorArm64` automaticamente. Compilado localmente neste
+host (`compileTestKotlinIosSimulatorArm64`, sem CocoaPods — mesma razão pela qual `:shared:core:security`
+já compilava em Linux desde a #118); a execução real depende do job `ios-xcode-macos`.
+
+## CI
+
+`aplicativo-ci.yml` (`ios-xcode-macos`) ganhou o step "Testar máquina de estados do cofre e
+biometria no simulador iOS" (`:shared:core:security:iosSimulatorArm64Test`) — **lacuna real
+corrigida, não introduzida por esta issue**: o módulo já existia desde a #118, mas nenhum job de CI
+executava seu `commonTest`/`iosTest` no simulador, só compilava (`ios-compilacao-linux`, sem
+`Test`). Essa run é a primeira execução real do runtime Kotlin/Native para este módulo.
+
+## Compatibilidade
+
+Nenhuma migração de banco — `DisponibilidadeBiometria`/`EstadoCofre`/`ResultadoAutenticacao` são
+tipos de domínio em memória, nunca persistidos (`PreferenciasCofre` guarda só `PoliticaProtecao`,
+inalterada). Cofres já criados, política de proteção já escolhida e o fluxo de quem usa só
+senha/PIN (`PoliticaProtecao.Nenhuma`) continuam exatamente como antes — a mudança é só na precisão
+da checagem de disponibilidade antes de oferecer/tentar a proteção biométrica.
+
+## Limitações registradas (não escondidas)
+
+- Sem device físico/emulador Android neste ambiente: `mapearDisponibilidade`/`mapearErro` do
+  Android são testados como funções puras (constantes reais da lib), não contra hardware real —
+  mesma limitação já registrada pela #118 para `BiometricPrompt`.
+- Sem macOS neste ambiente: `AutenticadorBiometricoIOS.disponibilidade()`/`autenticar()` (as
+  chamadas reais a `LAContext`) só são validadas de verdade pelo job `ios-xcode-macos` — o que este
+  ambiente valida é a compilação real (klib) e a execução dos mapeamentos puros com `NSError`
+  reais em `iosTest`.
+- `SecaoProtecao` (`AjustesScreens.kt`) checa disponibilidade só para o botão "Ativar proteção"
+  (combinação padrão, `permitirCredencialDispositivo = true`) — a alternância do chip "Permitir
+  código do aparelho além de biometria" numa proteção já ativa não foi gated por uma nova checagem
+  (fora do escopo desta issue, que pede ajuste de estados/mensagens de uma opção existente, não
+  redesenho); o usuário continua protegido contra ficar preso fora do cofre porque
+  `GerenciadorCofre.autenticarEAbrir()` já checa a disponibilidade real com a política efetivamente
+  configurada antes de qualquer tentativa.


### PR DESCRIPTION
## Inventário (auditoria antes de alterar código)

| Onde | O que havia | Observação |
|---|---|---|
| UI — opção de biometria | `CofreOnboarding.kt` (`TelaEscolherProtecao`, radios "Biometria"/"Credencial do aparelho") e `AjustesScreens.kt` (`SecaoProtecao`, botão "Ativar proteção") | Sempre habilitadas — o próprio código documentava a lacuna: *"não há contrato disponível para checar se o aparelho tem biometria configurada... as três opções ficam sempre habilitadas"* |
| commonMain ↔ disponibilidade | `AutenticadorBiometrico.disponibilidade()` sem parâmetro | Sempre checava a combinação "com credencial", mesmo quando a política/opção pedida era "biometria isolada" |
| Adapter Android | `AutenticadorBiometricoAndroid` (`BiometricManager.canAuthenticate`) | Uma única checagem combinada (`STRONG\|DEVICE_CREDENTIAL`); não diferenciava "sem sensor" de "sem PIN/senha nenhum" (mesmo código de erro para os dois) |
| Adapter iOS | `AutenticadorBiometricoIOS` (`LAContext.canEvaluatePolicy`) | Dois bugs de mapeamento reais (ver tabela abaixo) |
| Estados do cofre | `EstadoCofre.BiometriaIndisponivel` (`data object`, sem motivo) | Mensagem sempre genérica, não dizia se era falta de hardware, de cadastro ou de credencial |
| Fluxo de criação da proteção | `TelaEscolherProtecao` (onboarding) | Sem checagem prévia — só falhava no primeiro desbloqueio real |
| Fluxo de desbloqueio | `GerenciadorCofre.autenticarEAbrir()` | Checava disponibilidade sem refletir a política efetivamente configurada |
| Fallback para credencial do dispositivo | `PoliticaProtecao.Ativada.permitirCredencialDispositivo` | Já existia e continua — não criado nada novo |
| Mensagens de indisponibilidade | 1 string genérica (`cofre_biometria_indisponivel_*`) | Mesma mensagem para "sem sensor", "sem cadastro", "sem PIN", "bloqueio" |
| Cancelamento do usuário | `ResultadoAutenticacao.Cancelado` | Já tratado corretamente (não destrutivo) — mantido |
| Bloqueio temporário/permanente | `ResultadoAutenticacao.BloqueioTemporario` (só temporário) | Faltava caso "permanente"; iOS mapeava permanente como temporário (bug, ver abaixo) |
| Testes existentes | `GerenciadorCofreTest` (15), `AutenticadorBiometricoAndroidTest` (3, sem mapear códigos) | Nenhum teste cobria os estados que faltavam no modelo |
| Hardcode de disponibilidade | Nenhum `true` literal, mas UI nunca consultava o contrato real (equivalente na prática) | — |

### Problema encontrado (tabela pedida no escopo)

| Plataforma | Detecção atual (antes) | Problema | API correta | Ação |
|---|---|---|---|---|
| Android | `canAuthenticate(STRONG\|DEVICE_CREDENTIAL)` único | Não diferenciava "sem sensor" de "sem PIN/senha nenhum" (mesmo código `NO_HARDWARE`) | `canAuthenticate` chamado também isolado por `DEVICE_CREDENTIAL` | `mapearDisponibilidade` novo, puro, testável |
| Android | `ERROR_LOCKOUT_PERMANENT` → `FalhaCredencial` (texto livre) | Indistinguível de senha errada comum | `ResultadoAutenticacao.BloqueioPermanente` (novo caso) | `mapearErro` corrigido |
| iOS | `LAErrorPasscodeNotSet` → `SemHardware` | Mensagem incoerente ("sem sensor" quando falta é PIN/senha) | `LAErrorPasscodeNotSet` → `SemCredencialDispositivo` | `mapearDisponibilidade` novo |
| iOS | `LAErrorBiometryLockout` → bloqueio **temporário** de 30s fixos | Semanticamente errado — Apple exige confirmar credencial do aparelho pra resetar, não é temporizado | `LAErrorBiometryLockout` → `BloqueadaPermanentemente`/`BloqueioPermanente` | `mapearDisponibilidade`/`mapearErro` corrigidos |
| Ambas | `DisponibilidadeBiometria` com 4 casos, um deles com `String` livre | Não cobria "sem credencial", "bloqueio permanente", "erro desconhecido" | Modelo de 8 casos | `DisponibilidadeBiometria.kt` reescrito |
| `:shared:app` | UI nunca consultava disponibilidade real | Opções sempre habilitadas, falha só na primeira tentativa | `GerenciadorCofre.disponibilidadeBiometrica(...)` (novo) | `CofreOnboarding.kt`/`AjustesScreens.kt` |

## Estados suportados (commonMain)

`DisponibilidadeBiometria` (`:shared:core:security`, `commonMain`) — 8 casos: `Disponivel`,
`SemHardware`, `NaoConfigurada`, `SemCredencialDispositivo` (novo), `BloqueadaTemporariamente`
(novo, horário opcional), `BloqueadaPermanentemente` (novo), `Indisponivel` (novo, genérico
transitório), `ErroDesconhecido` (novo, com motivo — nunca finge "disponível" para código não
mapeado).

`DecisaoOpcaoProtecao` (novo, sem Compose/plataforma) decide de forma pura: `habilitada()`,
`permiteTentarNovamente()`, `permiteContinuarSemProtecao()` — testado isoladamente
(`DecisaoOpcaoProtecaoTest`).

`EstadoCofre.BiometriaIndisponivel` passou de `data object` para `data class(motivo:
DisponibilidadeBiometria)` — a UI usa o motivo real para título/mensagem/fallback.

`AutenticadorBiometrico.disponibilidade(permitirCredencialDispositivo: Boolean)` — ganhou
parâmetro; a checagem reflete a mesma combinação que uma tentativa real usaria. `GerenciadorCofre`
expõe `disponibilidadeBiometrica(...)` público para a UI consultar sem vazar o adapter nativo.

## Implementação Android

`AutenticadorBiometricoAndroid.disponibilidade()`: continua só `BIOMETRIC_STRONG` (+
`DEVICE_CREDENTIAL` quando a política permite) — `BIOMETRIC_WEAK` deliberadamente fora, sem decisão
de produto pedindo essa combinação. Mapeamento puro (`mapearDisponibilidade`, função de nível de
topo) cobre: sucesso, sem hardware, sem cadastro, atualização de segurança pendente, não suportado,
status desconhecido — diferencia "sem hardware" de "sem credencial do aparelho nenhuma" checando
`DEVICE_CREDENTIAL` isolado. `mapearErro` ganhou `ERROR_LOCKOUT_PERMANENT` →
`ResultadoAutenticacao.BloqueioPermanente`.

## Implementação iOS

`AutenticadorBiometricoIOS.disponibilidade()`: `canEvaluatePolicy` (nunca dispara prompt) com
`LAPolicyDeviceOwnerAuthenticationWithBiometrics` (biometria isolada) ou
`LAPolicyDeviceOwnerAuthentication` (biometria ou passcode) conforme o parâmetro — sempre uma
`LAContext()` nova por checagem (padrão Apple, já seguido por `autenticar`). `mapearDisponibilidade`/
`mapearErro` viraram funções puras/`internal`, testáveis com `NSError` reais, sem sensor físico nem
mock de `LAContext`. Nenhuma SPI privada usada — só `LocalAuthentication` público.

## Comportamento de fallback

"Continuar sem proteção" continua sempre presente em `EstadoCofre.BiometriaIndisponivel` (herdado
da #118) — garantia de que detecção errada de biometria nunca deixa o usuário preso fora do cofre.
"Tentar novamente" só aparece quando o motivo é transitório (`DecisaoOpcaoProtecao.permiteTentarNovamente`);
para "sem hardware"/"não configurada"/"sem credencial"/"bloqueio permanente" ele some (nada muda só
por clicar de novo). Na tela de onboarding, se a opção pré-selecionada não estiver disponível de
verdade, cai automaticamente para uma que esteja (nunca deixa "Continuar" seguir com uma opção
sabidamente quebrada).

## Testes

- `commonTest`: `GerenciadorCofreTest` (22 casos, era 15) cobre disponível, não cadastrada, sem
  hardware, sem credencial do dispositivo, bloqueio temporário (com e sem horário conhecido),
  bloqueio permanente (via disponibilidade e via tentativa real), erro desconhecido, cancelamento
  (já existia), fallback permitido/removido, política já configurada persistindo. Nova
  `DecisaoOpcaoProtecaoTest` (4 casos) cobre a decisão pura isolada.
- Android: `AutenticadorBiometricoAndroidTest` (15 casos, era 3) — `mapearDisponibilidade` e
  `mapearErro` viraram funções puras testadas com os próprios constantes de
  `BiometricManager`/`BiometricPrompt` (sem depender de hardware/emulador real).
- iOS: novo source set `iosTest` (não existia nenhum no repo antes — habilitado automaticamente
  pelo "default hierarchy template" do Kotlin 2.3.10, sem mudar `build.gradle.kts`).
  `AutenticadorBiometricoIOSTest` (14 casos) mapeia `LAError`/políticas com instâncias reais de
  `NSError`, sem sensor físico nem mock de `LAContext`.
- Nenhum teste depende de comparação de string visual completa — todas as asserções são sobre os
  tipos/casos do modelo (`DisponibilidadeBiometria`/`ResultadoAutenticacao`/`EstadoCofre`).
- Nenhum teste iOS pulado — `iosSimulatorArm64Test` do módulo passa a rodar de verdade no job
  macOS (ver seção CI).

## Compatibilidade

Nenhuma migração de banco — `DisponibilidadeBiometria`/`EstadoCofre`/`ResultadoAutenticacao` são
tipos de domínio em memória, nunca persistidos (`PreferenciasCofre` guarda só `PoliticaProtecao`,
inalterada). Cofres já criados, política já escolhida e o fluxo de quem usa só senha/PIN
(`PoliticaProtecao.Nenhuma`) continuam exatamente como antes.

## Limitações de simulador/emulador

- Sem device físico/emulador Android neste ambiente: mapeamentos Android testados como funções
  puras (constantes reais da lib), não contra hardware real — mesma limitação já registrada pela
  #118 para `BiometricPrompt`.
- Sem macOS neste ambiente de desenvolvimento: as chamadas reais a `LAContext` só são validadas de
  verdade pelo job `ios-xcode-macos` da CI (ver resultado abaixo) — localmente só validei
  compilação real dos klibs (`compileKotlinIosArm64`/`compileKotlinIosSimulatorArm64` e
  `compileTestKotlinIosSimulatorArm64`, todos verdes) e a execução dos mapeamentos puros.
- `SecaoProtecao` (Ajustes) checa disponibilidade só para o botão "Ativar proteção" (combinação
  padrão); a alternância do chip "permitir credencial" numa proteção já ativa não ganhou checagem
  nova (fora do escopo — "ajustar estados/mensagens de uma opção existente", não redesenho). O
  usuário continua protegido porque `GerenciadorCofre.autenticarEAbrir()` já checa a disponibilidade
  real com a política efetivamente configurada antes de qualquer tentativa.

## Resultado dos workflows de CI

Rodado localmente neste host (sem macOS/emulador Android) antes de abrir o PR:
- `verifyArchitecture`, `verifyDesignSystemTokens`, `verifyNoNetworkAccess` — verdes.
- `:shared:core:security:testDebugUnitTest` — verde (`GerenciadorCofreTest` 22, `DecisaoOpcaoProtecaoTest`
  4, `AutenticadorBiometricoAndroidTest` 15, `PreferenciasCofreAndroidTest` 4).
- `:shared:core:model`/`:testing`/`:designsystem`/`:backup`/`:domain:patrimonio`:testDebugUnitTest e
  `:androidApp:testDevDebugUnitTest` — verdes.
- `:shared:core:database:testDebugUnitTest` — **4 falhas pré-existentes, confirmadas também no
  `master` sem nenhuma mudança minha** (`RoomRepositorioItensPatrimoniaisContratoTest`, provável
  flake de ambiente Windows/Robolectric neste host) — não relacionado a esta issue, módulo não
  tocado por este PR.
- `:androidApp:lintDevDebug`, `:shared:core:designsystem:lintDebug`, `:androidApp:assembleDevDebug`
  — verdes.
- `compileKotlinIosArm64`/`compileKotlinIosSimulatorArm64` de `:shared:core:security`,
  `:shared:core:backup`, `:shared:core:model`, `:shared:domain:patrimonio` — verdes.
- `compileTestKotlinIosSimulatorArm64` de `:shared:core:security` (compila o novo `iosTest`) —
  verde.

**GitHub Actions real** (disparado pela abertura deste PR, SHA `1a96502`):

- `Validação de Pull Request` (`ci.yml`) — ✅ sucesso.
- `Aplicativo CI` (`aplicativo-ci.yml`, [run 30426749049](https://github.com/gmmattey/esquilo-wallet/actions/runs/30426749049)) — ✅ sucesso nos 5 jobs:
  - `Fronteira KMP e tokens do design system` (`verifyArchitecture`/`verifyDesignSystemTokens`/`verifyNoNetworkAccess`) — ✅
  - `Testes de commonTest e módulos compartilhados` (inclui `:shared:core:security:testDebugUnitTest`, `:shared:core:database:testDebugUnitTest`) — ✅ (confirma que a falha que vi localmente nesse módulo era flake do meu ambiente Windows, não algo deste PR — reproduzi a mesma falha rodando `master` sem nenhuma mudança minha, antes de investigar)
  - `Lint e build de desenvolvimento Android` — ✅
  - `Compilação dos klibs iOS (sem link, sem macOS)` — ✅
  - `Link do framework e build do Xcode (runner macOS)` — ✅, incluindo o novo step
    `:shared:core:security:iosSimulatorArm64Test` (primeira execução real do `commonTest`/`iosTest`
    deste módulo em simulador iOS de verdade — antes só compilava), a confirmação de ausência de
    símbolo privado do CommonCrypto, e o build do `iosApp` no Xcode.

Nenhum job pulado, nenhum teste iOS skipped.

## Recomendação

**Recomendo fechar a #226.** Todos os critérios da seção 9: disponibilidade não é mais presumida
em nenhum ponto (onboarding e Ajustes checam o contrato real antes de habilitar qualquer opção);
Android usa `BiometricManager` corretamente (biometria isolada vs. combinada, diferenciando "sem
hardware" de "sem credencial"); iOS usa `LAContext` corretamente (política certa por combinação,
`canEvaluatePolicy` nunca dispara prompt, instância nova por checagem); os 8 estados do modelo
compartilhado cobertos nos dois adapters; a opção de biometria respeita hardware/configuração reais
nas duas telas que a expõem; fallback ("continuar sem proteção") nunca falta quando a opção não está
disponível — o usuário nunca fica preso fora do cofre; cofres existentes continuam funcionando (sem
migração, tipos novos são só em memória); CI Android e iOS verde no SHA final (`1a96502`), incluindo
a primeira execução real do `iosSimulatorArm64Test` deste módulo.

Closes #226
