### PR TITLE
release: preparar Savro 0.1.0 para teste interno

### DIFF
--- a/.github/workflows/android-internal-release.yml
+++ b/.github/workflows/android-internal-release.yml
@@ -1,0 +1,147 @@
+name: Android Internal Release
+
+# Gera o AAB release assinado do Savro para o primeiro teste interno no Play Console (#241).
+# Disparo manual apenas — não publica em loja, não cadastra service account.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: android-internal-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  BUNDLETOOL_VERSION: "1.17.1"
+
+jobs:
+  build-signed-aab:
+    name: Gerar e validar AAB release assinado
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: aplicativo
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Validar Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+
+      - name: Configurar JDK 17
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Configurar Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Instalar plataforma Android 36
+        run: sdkmanager "platforms;android-36"
+
+      - name: Configurar cache do Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+
+      - name: Verificar arquitetura, tokens e ausência de rede
+        run: ./gradlew --no-daemon --stacktrace verifyArchitecture verifyDesignSystemTokens verifyNoNetworkAccess
+
+      - name: Executar commonTest e módulos compartilhados
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            :shared:core:model:testDebugUnitTest \
+            :shared:core:testing:testDebugUnitTest \
+            :shared:core:designsystem:testDebugUnitTest \
+            :shared:core:database:testDebugUnitTest \
+            :shared:core:security:testDebugUnitTest \
+            :shared:core:backup:testDebugUnitTest \
+            :shared:domain:patrimonio:testDebugUnitTest
+
+      - name: Executar testes unitários Android (:androidApp)
+        run: ./gradlew --no-daemon --stacktrace :androidApp:testDevDebugUnitTest
+
+      - name: Lint release
+        run: ./gradlew --no-daemon --stacktrace :androidApp:lintDevRelease
+
+      # A chave de upload nunca é versionada. Só o segredo em base64 existe em CI; é reconstruída
+      # aqui num arquivo temporário do runner e removida no fim do job (passo com if: always()),
+      # mesmo se um passo anterior falhar.
+      - name: Reconstruir keystore de upload
+        env:
+          SAVRO_UPLOAD_KEYSTORE_BASE64: ${{ secrets.SAVRO_UPLOAD_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "${SAVRO_UPLOAD_KEYSTORE_BASE64:-}" ]; then
+            echo "Secret SAVRO_UPLOAD_KEYSTORE_BASE64 não configurado — sem chave de upload, o bundleDevRelease abaixo vai falhar na assinatura (esperado até a chave existir)." >&2
+            exit 1
+          fi
+          KEYSTORE_PATH="$RUNNER_TEMP/savro-upload-keystore.jks"
+          echo "$SAVRO_UPLOAD_KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_PATH"
+          echo "SAVRO_UPLOAD_KEYSTORE_PATH=$KEYSTORE_PATH" >> "$GITHUB_ENV"
+
+      - name: Gerar AAB release assinado (bundleDevRelease)
+        env:
+          SAVRO_UPLOAD_STORE_PASSWORD: ${{ secrets.SAVRO_UPLOAD_STORE_PASSWORD }}
+          SAVRO_UPLOAD_KEY_ALIAS: ${{ secrets.SAVRO_UPLOAD_KEY_ALIAS }}
+          SAVRO_UPLOAD_KEY_PASSWORD: ${{ secrets.SAVRO_UPLOAD_KEY_PASSWORD }}
+        run: ./gradlew --no-daemon --stacktrace :androidApp:bundleDevRelease
+
+      - name: Localizar AAB gerado
+        run: |
+          AAB_PATH=$(find androidApp/build/outputs/bundle/devRelease -name "*.aab" | head -n 1)
+          if [ -z "$AAB_PATH" ]; then
+            echo "Nenhum .aab encontrado em androidApp/build/outputs/bundle/devRelease" >&2
+            exit 1
+          fi
+          echo "AAB_PATH=aplicativo/$AAB_PATH" >> "$GITHUB_ENV"
+          echo "AAB gerado em $AAB_PATH"
+
+      - name: Baixar bundletool
+        run: |
+          curl -sSL -o "$RUNNER_TEMP/bundletool.jar" \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar"
+
+      # Inspeção do AAB: package, versionCode, versionName e debuggable a partir do Manifest real
+      # embutido no bundle (protobuf) — aapt2 não lê esse formato, por isso bundletool.
+      - name: Inspecionar Manifest do AAB (package, versão, debuggable)
+        working-directory: .
+        run: |
+          java -jar "$RUNNER_TEMP/bundletool.jar" dump manifest --bundle="$AAB_PATH" > "$RUNNER_TEMP/manifest-dump.txt"
+          cat "$RUNNER_TEMP/manifest-dump.txt"
+
+          fail=0
+          grep -q 'package="io.savro.app"' "$RUNNER_TEMP/manifest-dump.txt" || { echo "package incorreto (esperado io.savro.app)" >&2; fail=1; }
+          grep -q 'versionCode="1"' "$RUNNER_TEMP/manifest-dump.txt" || { echo "versionCode incorreto (esperado 1)" >&2; fail=1; }
+          grep -q 'versionName="0.1.0"' "$RUNNER_TEMP/manifest-dump.txt" || { echo "versionName incorreto (esperado 0.1.0)" >&2; fail=1; }
+          grep -q 'debuggable="true"' "$RUNNER_TEMP/manifest-dump.txt" && { echo "AAB está debuggable=true — inaceitável para release" >&2; fail=1; }
+          grep -qi '\.dev"' "$RUNNER_TEMP/manifest-dump.txt" && { echo "package contém sufixo .dev — build errado (deveria ser bundleDevRelease, não debug)" >&2; fail=1; }
+          grep -qi '\-dev"' "$RUNNER_TEMP/manifest-dump.txt" && { echo "versionName contém sufixo -dev — build errado" >&2; fail=1; }
+          [ "$fail" -eq 0 ] || exit 1
+          echo "Manifest do AAB validado: io.savro.app, versionCode=1, versionName=0.1.0, debuggable=false, sem sufixo .dev/-dev."
+
+      - name: Validar assinatura do AAB
+        working-directory: .
+        run: |
+          jarsigner -verify -verbose -certs "$AAB_PATH" | tee "$RUNNER_TEMP/jarsigner-output.txt"
+          grep -q "jar verified" "$RUNNER_TEMP/jarsigner-output.txt" || { echo "Assinatura do AAB não verificada — bundle não confiável para o Play Console" >&2; exit 1; }
+
+      - name: Calcular SHA-256 do AAB
+        working-directory: .
+        run: sha256sum "$AAB_PATH" | tee "$RUNNER_TEMP/savro-0.1.0-internal.sha256"
+
+      - name: Publicar artifact privado
+        uses: actions/upload-artifact@v4
+        with:
+          name: savro-0.1.0-internal-aab
+          path: |
+            ${{ env.AAB_PATH }}
+            ${{ runner.temp }}/savro-0.1.0-internal.sha256
+          retention-days: 7
+          if-no-files-found: error
+
+      # Roda mesmo se um passo anterior falhou — a chave nunca fica no runner além deste job.
+      - name: Apagar keystore temporário
+        if: always()
+        run: rm -f "${SAVRO_UPLOAD_KEYSTORE_PATH:-}"

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,11 @@ aplicativo/**/*.apk
 aplicativo/**/*.aab
 aplicativo/**/*.apks
 
+# Chave de upload do Play Console (#241) — nunca versionar
+aplicativo/**/*.jks
+aplicativo/**/*.keystore
+aplicativo/keystore.properties
+
 # Gradle rodado por engano fora de aplicativo/ (raiz do repo não é projeto Gradle)
 /.gradle/
 /.kotlin/

--- a/aplicativo/androidApp/build.gradle.kts
+++ b/aplicativo/androidApp/build.gradle.kts
@@ -1,8 +1,41 @@
+import java.util.Base64
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
+
+// Assinatura de upload (#241): nunca versionada. As variáveis vêm do ambiente (CI) ou de
+// gradle.properties local (fora do controle de versão, ver .gitignore). Sem elas, o buildType
+// release simplesmente não recebe signingConfig — falha explícita do Gradle no bundleRelease em
+// vez de assinar silenciosamente com uma chave de debug.
+val uploadKeystorePath: String? = System.getenv("SAVRO_UPLOAD_KEYSTORE_PATH")
+val uploadKeystoreBase64: String? = System.getenv("SAVRO_UPLOAD_KEYSTORE_BASE64")
+val uploadStorePassword: String? = System.getenv("SAVRO_UPLOAD_STORE_PASSWORD")
+val uploadKeyAlias: String? = System.getenv("SAVRO_UPLOAD_KEY_ALIAS")
+val uploadKeyPassword: String? = System.getenv("SAVRO_UPLOAD_KEY_PASSWORD")
+
+// Reconstrói o keystore em um arquivo temporário quando só o base64 está disponível (CI). O
+// workflow que injeta SAVRO_UPLOAD_KEYSTORE_BASE64 é responsável por apagar esse arquivo depois
+// (rm -f com `if: always()`), não este build script.
+val resolvedUploadKeystoreFile: File? = when {
+    uploadKeystorePath != null -> file(uploadKeystorePath)
+    uploadKeystoreBase64 != null -> {
+        val decoded = Base64.getDecoder().decode(uploadKeystoreBase64)
+        File.createTempFile("savro-upload-keystore-", ".jks").apply {
+            writeBytes(decoded)
+            deleteOnExit()
+        }
+    }
+    else -> null
+}
+
+val uploadSigningAvailable =
+    resolvedUploadKeystoreFile != null &&
+        uploadStorePassword != null &&
+        uploadKeyAlias != null &&
+        uploadKeyPassword != null
 
 android {
     namespace = "io.savro.app"
@@ -24,6 +57,17 @@ android {
         }
     }
 
+    if (uploadSigningAvailable) {
+        signingConfigs {
+            create("upload") {
+                storeFile = resolvedUploadKeystoreFile
+                storePassword = uploadStorePassword
+                keyAlias = uploadKeyAlias
+                keyPassword = uploadKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         debug {
             applicationIdSuffix = ".dev"
@@ -31,6 +75,10 @@ android {
         }
         release {
             isMinifyEnabled = false
+            isDebuggable = false
+            if (uploadSigningAvailable) {
+                signingConfig = signingConfigs.getByName("upload")
+            }
         }
     }
 

--- a/documentacao/release/play-console-teste-interno.md
+++ b/documentacao/release/play-console-teste-interno.md
@@ -1,0 +1,148 @@
+# Play Console — Teste Interno (Savro 0.1.0)
+
+Guia para gerar e validar o primeiro AAB assinado do Savro, destinado ao envio manual à faixa de
+teste interno do Google Play Console (#241). Não cobre ficha de loja, screenshots, IARC, Data
+Safety ou publicação — isso é preparação posterior (#225, #227), fora do escopo deste documento.
+
+## Identidade da versão
+
+| Campo | Valor |
+|---|---|
+| `applicationId` | `io.savro.app` |
+| `versionCode` | `1` |
+| `versionName` | `0.1.0` |
+| Nome do app | Savro |
+
+Esses valores são fixos em `aplicativo/androidApp/build.gradle.kts` (`defaultConfig`). Incrementar
+`versionCode` é obrigatório a cada novo envio ao Play Console — ver seção final.
+
+## 1. Geração da chave de upload
+
+**Não existe ainda uma chave de upload definitiva para o Savro.** Ela não deve ser gerada
+silenciosamente por automação, nem reaproveitada da chave usada pelo SignallQ — cada produto tem
+sua própria chave de assinatura.
+
+O Luiz deve gerar localmente, com `keytool` (parte do JDK):
+
+```bash
+keytool -genkeypair -v \
+  -keystore savro-upload-keystore.jks \
+  -alias savro-upload \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000
+```
+
+O comando pede uma senha do keystore (store password) e, por padrão, reaproveita a mesma senha
+para a chave (key password) — pode-se optar por senhas diferentes respondendo `n` quando
+perguntado. Guarde as duas senhas e o arquivo `.jks` em um cofre de senhas (não em disco solto, não
+no repositório).
+
+Recomendação: gerar em um diretório fora do repositório (ex. `~/keys/savro/`), nunca dentro de
+`aplicativo/`.
+
+## 2. Secrets necessários
+
+O workflow `android-internal-release.yml` e o build script (`androidApp/build.gradle.kts`) aceitam
+as seguintes variáveis — em CI, via **GitHub Actions repository secrets**; localmente, via
+variável de ambiente ou `gradle.properties` (fora do controle de versão):
+
+| Nome | Uso | Onde configurar |
+|---|---|---|
+| `SAVRO_UPLOAD_KEYSTORE_BASE64` | Conteúdo do `.jks` codificado em base64 | Secret do repositório (usado pelo workflow de CI) |
+| `SAVRO_UPLOAD_KEYSTORE_PATH` | Caminho absoluto do `.jks` no disco | Variável de ambiente local (build manual, fora de CI) |
+| `SAVRO_UPLOAD_STORE_PASSWORD` | Senha do keystore | Secret do repositório / variável de ambiente local |
+| `SAVRO_UPLOAD_KEY_ALIAS` | Alias da chave (`savro-upload`) | Secret do repositório / variável de ambiente local |
+| `SAVRO_UPLOAD_KEY_PASSWORD` | Senha da chave | Secret do repositório / variável de ambiente local |
+
+O build script usa `SAVRO_UPLOAD_KEYSTORE_PATH` **ou** `SAVRO_UPLOAD_KEYSTORE_BASE64` (o primeiro
+que existir); nunca os dois ao mesmo tempo. O workflow de CI usa exclusivamente a variante base64 —
+reconstrói o `.jks` num arquivo temporário do runner e apaga esse arquivo ao final do job
+(`if: always()`), mesmo se algum passo anterior falhar.
+
+Cadastro dos secrets no repositório (`buildea-labs/savro`) **não faz parte desta issue** — fica
+para quando o Luiz gerar a chave real e decidir cadastrá-los.
+
+Gerar o base64 a partir do `.jks` (Linux/macOS):
+
+```bash
+base64 -w0 savro-upload-keystore.jks > savro-upload-keystore.b64
+```
+
+No Windows (PowerShell):
+
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("savro-upload-keystore.jks")) | Out-File -Encoding ascii savro-upload-keystore.b64
+```
+
+## 3. Execução do workflow
+
+`.github/workflows/android-internal-release.yml` é disparado manualmente
+(`workflow_dispatch`) — Actions → "Android Internal Release" → Run workflow, na branch desejada.
+
+O que o workflow faz, em ordem:
+
+1. `verifyArchitecture`, `verifyDesignSystemTokens`, `verifyNoNetworkAccess`.
+2. `commonTest` dos módulos compartilhados (`:shared:core:*`, `:shared:domain:patrimonio`).
+3. Testes unitários de `:androidApp` (`testDevDebugUnitTest`).
+4. Lint de release (`:androidApp:lintDevRelease`).
+5. Reconstrói o keystore de upload a partir do secret base64.
+6. Gera o bundle assinado: `:androidApp:bundleDevRelease`.
+7. Inspeciona o Manifest do `.aab` via `bundletool dump manifest` — confirma `package`,
+   `versionCode`, `versionName`, `debuggable=false` e ausência de sufixo `.dev`/`-dev`.
+8. Valida a assinatura do bundle (`jarsigner -verify`).
+9. Calcula o SHA-256 do `.aab`.
+10. Publica o artifact privado `savro-0.1.0-internal-aab` (retenção de 7 dias).
+11. Apaga o keystore temporário do runner (`if: always()`).
+
+Sem os secrets cadastrados, o workflow falha explicitamente no passo de reconstrução do keystore —
+não existe fallback silencioso para uma chave de debug.
+
+## 4. Download e validação do artifact
+
+No run concluído do workflow, aba "Summary" → seção Artifacts → baixar `savro-0.1.0-internal-aab`
+(contém o `.aab` e um arquivo `.sha256`).
+
+Validação manual adicional antes do envio ao Play Console:
+
+```bash
+# Conferir o hash contra o savro-0.1.0-internal.sha256 do artifact
+sha256sum caminho/para/androidApp-dev-release.aab
+
+# Conferir package/versão/debuggable (requer bundletool — mesma versão do workflow)
+java -jar bundletool.jar dump manifest --bundle=caminho/para/androidApp-dev-release.aab
+```
+
+## 5. Envio manual ao Play Console
+
+Fora do escopo de automação desta issue — feito manualmente pelo Luiz:
+
+1. Play Console → Savro → Teste → Interno → Criar nova versão.
+2. Upload do `.aab` baixado do artifact.
+3. Preencher notas da versão (ver seção abaixo).
+4. Salvar e revisar — **não enviar para revisão/publicação** sem decisão explícita do Luiz.
+
+## 6. Notas da versão (sugestão para o Play Console)
+
+```
+Savro 0.1.0 — primeira versão de teste interno.
+
+App de organização patrimonial local-first: os dados nunca saem do aparelho. Versão inicial
+para validação interna antes da ficha de loja completa.
+```
+
+Ajustar conforme o que efetivamente estiver funcional no momento do envio.
+
+## 7. Incremento futuro de versionCode
+
+Cada novo envio ao Play Console (mesmo faixa de teste interno) exige `versionCode` estritamente
+maior que o anterior — o Play Console rejeita reenvio com o mesmo `versionCode`. Antes do próximo
+envio:
+
+1. Incrementar `versionCode` em `aplicativo/androidApp/build.gradle.kts` (`defaultConfig`).
+2. Atualizar `versionName` se a mudança for visível ao usuário (ex. `0.1.1`, `0.2.0`) — versionCode
+   sobe sempre, versionName é decisão de produto.
+3. Rodar o workflow novamente para gerar o novo `.aab` assinado.
+
+Este documento não cobre a política de quando subir `versionName` (minor vs. patch) — isso é
+decisão de produto a ser tomada quando houver mais de uma versão em campo.


### PR DESCRIPTION
Closes #241

## Objetivo

Deixar o ambiente pronto para gerar o primeiro AAB assinado do Savro 0.1.0 destinado ao teste interno do Play Console — sem publicar, sem cadastrar service account, sem alterar identidade do app.

## Identidade (inalterada)

- `applicationId`: `io.savro.app`
- `versionCode`: `1`
- `versionName`: `0.1.0`
- nome: Savro

## O que entrou

- `aplicativo/androidApp/build.gradle.kts`: `signingConfigs.upload` condicional, lido de variáveis de ambiente. Sem elas, `release` não recebe signingConfig — build gera AAB não assinado, nunca assinado silenciosamente com chave de debug (confirmado no run real). `isDebuggable = false` explícito no buildType release.
- `.github/workflows/android-internal-release.yml`: workflow manual (`workflow_dispatch`) que testa, gera `:androidApp:bundleDevRelease`, valida package/versionCode/versionName/debuggable via `bundletool dump manifest`, valida assinatura com `jarsigner -verify`, calcula SHA-256 e publica o artifact `savro-0.1.0-internal-aab` (retenção 7 dias). Apaga o keystore temporário do runner com `if: always()`.
- `documentacao/release/play-console-teste-interno.md`: geração da chave de upload, secrets necessários, execução do workflow, download/validação do artifact, envio manual ao Play Console, notas de versão, incremento futuro de `versionCode`.
- `.gitignore`: ignora `.jks`/`.keystore`/`keystore.properties` dentro de `aplicativo/`.

## Chave de upload — gerada nesta rodada

`savro-upload.jks` (RSA 4096, JKS, validade 10000 dias, notAfter 2053-12-14), guardada fora do repositório e em nota segura no Bitwarden do Luiz. Não reaproveita a chave do SignallQ.

- SHA-1: `42:97:89:E6:B5:C0:36:99:65:3F:0D:24:92:F1:70:C4:38:E1:6D:45`
- SHA-256: `87:DE:F4:5A:26:78:A2:0D:5B:E9:8A:12:32:40:37:99:D9:E3:1D:D7:28:43:EB:B9:13:CB:9E:B8:FB:AA:E1:8B`

Secrets cadastrados em `buildea-labs/savro`: `SAVRO_UPLOAD_KEYSTORE_BASE64`, `SAVRO_UPLOAD_STORE_PASSWORD`, `SAVRO_UPLOAD_KEY_ALIAS`, `SAVRO_UPLOAD_KEY_PASSWORD`.

## Run real

https://github.com/buildea-labs/savro/actions/runs/30501095435 — `success`. AAB `androidApp-dev-release.aab`, 21.517.764 bytes, SHA-256 `3a223374189f12a46289b43261496ae04531aa2060028cd00dcd6b7ea575993c`, manifest e assinatura validados. Detalhes completos no comentário desta PR.

## Nota sobre o merge

Esta PR foi mergeada (squash) **antes** de existir o AAB real — necessário porque `workflow_dispatch` só é disparável para workflows já presentes na branch padrão (`master`); não havia como rodar o workflow real com o arquivo só na branch de feature. Decisão aprovada explicitamente pelo Luiz nesta rodada. O AAB real foi gerado logo em seguida, no run acima, já em `master`.

Não publicado no Play Console.