### PR TITLE
chore: renomear publicação Cloudflare Pages para Savro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           # configurada" (sitemap/robots/canonical indexáveis) também na validação de PR.
           # Não é obrigatória aqui: sem ela o build de apresentacao/ ainda passa, só gera
           # robots.txt/sitemap.xml não indexáveis (ver scripts/gerar-arquivos-seo.mjs).
-          VITE_PUBLIC_SITE_URL: https://ei-raiz-web.pages.dev
+          VITE_PUBLIC_SITE_URL: https://savro-site.pages.dev
           VITE_SUPPORT_EMAIL: suporte.savro@gmail.com
 
       - name: Impedir alterações em legado

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
 
 env:
-  # Domínio Cloudflare Pages atual do projeto Esquilo — o Savro não tem domínio próprio ainda
+  # Domínio Cloudflare Pages atual do projeto Savro — o Savro não tem domínio próprio ainda
   # (issue #122). Não é segredo, só o único lugar onde o valor real deveria viver. Trocar aqui
   # quando um domínio próprio for registrado; nenhum outro arquivo precisa mudar.
-  PUBLIC_SITE_URL: https://ei-raiz-web.pages.dev
+  PUBLIC_SITE_URL: https://savro-site.pages.dev
   # Canal oficial de suporte/privacidade do Savro (issue #122) — não é segredo, é o contato
   # público exibido em Privacidade/Termos/Suporte/footer. Trocar aqui se o canal mudar.
   SUPPORT_EMAIL: suporte.savro@gmail.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ esquilo-wallet/
 
 ## Frontend (`apresentacao/`)
 
-React + Vite → Cloudflare Pages (`ei-raiz-web`). Hoje é só a landing (`features/landing/`) e as
+React + Vite → Cloudflare Pages (`savro-site`). Hoje é só a landing (`features/landing/`) e as
 páginas legais (`features/legal/`) — o wrapper Capacitor e o runtime patrimonial autenticado
 (login, dashboard, carteira, aportes, insights, importação, decisões, perfil, admin) foram
 removidos na #184.
@@ -42,7 +42,7 @@ removidos na #184.
 Automático via GitHub Actions (`.github/workflows/deploy.yml`) a cada push em `master`:
 typecheck → build → deploy no Cloudflare Pages.
 
-URL: https://ei-raiz-web.pages.dev
+URL: https://savro-site.pages.dev
 
 ### Variáveis de ambiente (`apresentacao/wrangler.toml`)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Este monorepo também hospeda a landing institucional do Savro.
 - **Web (`apresentacao/`):** landing institucional do Savro + páginas legais
   (`/privacidade`, `/termos`, `/suporte`, `/faq`, `/changelog`). Não é mais um app patrimonial —
   o wrapper Capacitor e o runtime React de login/dashboard/carteira foram encerrados na issue
-  #184. Publicada em https://esquilo.wallet e https://ei-raiz-web.pages.dev.
+  #184. Publicada em https://savro-site.pages.dev.
 - **Backend patrimonial:** encerrado (#184 congelou, #235 decidiu o desligamento). O Worker
   `ei-api-gateway` e os bancos D1 (`esquilo-invest`, `esquilo-invest-dev`, `esquilo-invest-hml`)
   foram excluídos da Cloudflare; o código em `servidores/porta-entrada/`, os contratos

--- a/apresentacao/e2e/landing.spec.ts
+++ b/apresentacao/e2e/landing.spec.ts
@@ -19,7 +19,7 @@ const APRESENTACAO_DIR = path.resolve(__dirname, '..');
 // Precisa bater com a env var usada para gerar o build servido em `npm run preview` (ver
 // playwright.config.ts / README de teste). Fallback é o domínio Cloudflare Pages real do
 // projeto — o mesmo usado em produção (.github/workflows/deploy.yml) — nunca um placeholder.
-const TEST_SITE_URL = (process.env.VITE_PUBLIC_SITE_URL ?? 'https://ei-raiz-web.pages.dev').replace(/\/+$/, '');
+const TEST_SITE_URL = (process.env.VITE_PUBLIC_SITE_URL ?? 'https://savro-site.pages.dev').replace(/\/+$/, '');
 
 const PUBLIC_ROUTES: { path: string }[] = JSON.parse(
   readFileSync(path.resolve(APRESENTACAO_DIR, 'src/config/public-routes.json'), 'utf-8')

--- a/apresentacao/package.json
+++ b/apresentacao/package.json
@@ -8,7 +8,7 @@
     "prebuild": "node scripts/gerar-arquivos-seo.mjs",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "deploy": "wrangler pages deploy dist --project-name ei-raiz-web --commit-dirty=true"
+    "deploy": "wrangler pages deploy dist --project-name savro-site --commit-dirty=true"
   },
   "dependencies": {
     "framer-motion": "^12.38.0",

--- a/apresentacao/wrangler.toml
+++ b/apresentacao/wrangler.toml
@@ -1,4 +1,4 @@
-name = "ei-raiz-web"
+name = "savro-site"
 compatibility_date = "2026-04-09"
 pages_build_output_dir = "./dist"
 
@@ -7,7 +7,7 @@ pages_build_output_dir = "./dist"
 # Consumida em build-time por scripts/gerar-arquivos-seo.mjs e src/config/site.ts. O deploy real
 # (.github/workflows/deploy.yml) passa esta mesma env var explicitamente ao `npm run build`; este
 # valor aqui documenta o que o build de produção usa e serve `wrangler pages dev` local.
-VITE_PUBLIC_SITE_URL = "https://ei-raiz-web.pages.dev"
+VITE_PUBLIC_SITE_URL = "https://savro-site.pages.dev"
 # Canal oficial de suporte/privacidade do Savro (issue #122), aprovado pelo Luiz. Fonte única
 # consumida por src/config/platforms.ts (SUPPORT_EMAIL) — Privacidade, Termos, Suporte e
 # StoreLinks só usam este valor, nunca um e-mail hardcoded no componente.


### PR DESCRIPTION
## Resumo

- Projeto Cloudflare Pages legado `ei-raiz-web` renomeado no dashboard pra `savro`, mas o subdomínio `.pages.dev` **não** acompanhou o rename (fica travado no valor de criação) — confirmado testando manualmente.
- Como fallback (regra da task): criado projeto Pages novo via API/wrangler.
  - `savro` — indisponível (nome já ocupado pelo projeto legado renomeado).
  - `savro-app` — rejeitado pela API da Cloudflare com erro genérico (`code 8000000`, mesmo em requisição raw à API, reproduzido isoladamente).
  - `savro-site` — criado com sucesso. **Nova URL pública: `https://savro-site.pages.dev`**.
- Deploy manual de validação já publicado e testado (200 em `/`, `/privacidade`, `/termos`, `/suporte`) antes de tocar em código.
- Atualizado `wrangler.toml`, `apresentacao/package.json` (script `deploy`), `.github/workflows/deploy.yml`, `.github/workflows/ci.yml`, `README.md`, `CLAUDE.md` e o fallback de URL em `apresentacao/e2e/landing.spec.ts` para `savro-site`.
- Não mexi nos arquivos `_archive/` (histórico, referência antiga preservada de propósito) nem no app KMP.
- Projeto Cloudflare Pages antigo (`ei-raiz-web`, hoje exibido como `savro`) **não foi desativado nem excluído** — decisão final fica pra depois da validação do deploy pós-merge.

## Plano de teste

- [x] Build local com `VITE_PUBLIC_SITE_URL=https://savro-site.pages.dev`
- [x] Deploy manual via wrangler pro projeto `savro-site`
- [x] `/`, `/privacidade`, `/termos`, `/suporte` retornando HTTP 200 em `savro-site.pages.dev`
- [x] `npm run typecheck` passando
- [ ] CI (`Validação de Pull Request`) verde nesta PR
- [ ] Deploy automático (`Deploy to Cloudflare`) verde após o merge, usando o novo projeto