### PR TITLE
docs: atualiza referências pós-migração e consolida CLAUDE.md/AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@AGENTS.md
+
 # Savro — Guia do Ambiente
 
 Savro é um app de organização patrimonial **local-first** para investidores brasileiros: Android e
@@ -15,7 +17,7 @@ patrimonial ativo: o Worker Cloudflare `ei-api-gateway` e os bancos D1 do produt
 ## Estrutura do Monorepo
 
 ```
-esquilo-wallet/
+savro/
 ├── aplicativo/             # App KMP Android + iOS — mobile oficial, local-first
 ├── apresentacao/           # Landing institucional + páginas legais → Cloudflare Pages
 ├── bibliotecas/
@@ -68,11 +70,7 @@ Não segue as convenções deste documento — é um módulo Gradle/Kotlin próp
 - DTOs em `camelCase`; tipos em `PascalCase`.
 - Sufixos: `Entrada`, `Saida`, `Filtro`, `Resumo`, `Dto`.
 
-### Palavras banidas no código
-
-Herdadas do domínio patrimonial (`portfolio`, `financial-core`, `insights`/`analytics`,
-`carteira`, `assets`, `posicoes`, `snapshot`, `unified`/`_v2`) — não reintroduzir sem decisão
-explícita de trazer de volta um backend patrimonial.
+Vocabulário canônico e palavras banidas: ver `AGENTS.md` §7.
 
 ---
 

--- a/documentacao/arquitetura/ADR-001-savro-android-local-first.md
+++ b/documentacao/arquitetura/ADR-001-savro-android-local-first.md
@@ -229,6 +229,14 @@ Este segundo adendo é só registro de leitura das issues — não cria a ADR-00
 aprovada e fechada, criar `ADR-002-savro-kmp-multiplataforma.md` (ou nome equivalente) como a nova
 ADR canônica, marcando esta ADR-001 como histórica de forma definitiva.
 
+## Adendo — 2026-08-03 — correção de nomenclatura (não é decisão nova)
+
+O texto acima (linhas 29 e 200-219) registra `esquilo-wallet`/`gmmattey/esquilo-wallet` como
+repositório durante a transição — já estava desatualizado antes deste adendo (o repo real é
+`buildea-labs/savro`, não `gmmattey/esquilo-wallet`) e a pasta local foi renomeada de
+`esquilo-wallet/` para `savro/` em 2026-08-03, equalizando com o nome do repo. Não altera nenhuma
+decisão arquitetural — só corrige a referência de nome/caminho pra quem ler este ADR depois.
+
 ## Critérios de aceite da #174
 
 - [x] Nome de trabalho, namespace, IDs e recursos documentados.


### PR DESCRIPTION
## Resumo

- \`CLAUDE.md\` agora importa \`@AGENTS.md\` no topo — antes o Claude Code (que só lê \`CLAUDE.md\` nativamente) não enxergava as regras operacionais, persona e proibições que só existiam em \`AGENTS.md\`.
- Diagrama de estrutura em \`CLAUDE.md\` atualizado: \`esquilo-wallet/\` → \`savro/\` (pasta local renomeada em 2026-08-03 pra bater com o nome do repo).
- \`ADR-001\`: adendo novo (não reescreve a decisão original) corrigindo a referência de repositório — já estava errada antes de hoje (\`buildea-labs/savro\`, não \`gmmattey/esquilo-wallet\`).

Sem mudança de comportamento, só documentação.